### PR TITLE
example.go doesn't handle returned metadata

### DIFF
--- a/_examples/example.go
+++ b/_examples/example.go
@@ -41,7 +41,7 @@ type clients struct {
 
 func main() {
 	var config tomlConfig
-	if err := toml.DecodeFile("example.toml", &config); err != nil {
+	if _, err := toml.DecodeFile("example.toml", &config); err != nil {
 		fmt.Println(err)
 		return
 	}


### PR DESCRIPTION
The example,go doesn't handle or ignore the returned metadata from toml.DecodeFile
