### PR TITLE
Add a test for empty slice

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -141,6 +141,10 @@ ArrayOfSlicesOfArrays = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
 SliceOfMixedArrays = [[1, 2], ["a", "b"]]
 ArrayOfMixedSlices = [[1, 2], ["a", "b"]]`,
 		},
+		"empty slice": {
+			input: struct { Empty []interface{} }{[]interface{}{}},
+			wantOutput: `Empty = []`,
+		},
 		"(error) slice with element type mismatch (string and integer)": {
 			input:     struct{ Mixed []interface{} }{[]interface{}{1, "a"}},
 			wantError: ErrArrayMixedElementTypes,


### PR DESCRIPTION
---

Reverting 13f832b doesn’t make toml-test fail, and I couldn't figure why, so I added a test to TestEncode directly (which does fail if 13f832b is reverted).

Thanks for considering!
