### PR TITLE
Revert d8a57f7; introduces spurious newlines when encoding TextMarshaler

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -63,6 +63,12 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) error {
 
 	// Special case. If we can marshal the type to text, then we used that.
 	if _, ok := rv.Interface().(TextMarshaler); ok {
+		if enc.hasWritten {
+			_, err := enc.w.Write([]byte{'\n'})
+			if err != nil {
+				return err
+			}
+		}
 		err := enc.eKeyEq(key)
 		if err != nil {
 			return err


### PR DESCRIPTION
Commit d8a57f7 in encode.go:

  fixing an encoding error where subelements of a table appear on the
  same line

wasn't actually a proper fix, and introduces spurious newlines instead.

I believe the motivation of this commit was observing datetime objects
come out like:

  Int = 1Date = 2014-05-11T12:30:40Z

but that was due to time.Time objects not being treated like primitives, and
being treated like a struct instead (time.Time's Kind is reflect.Struct).

This commit includes tests in TextEncode that show the error in d8a57f7.
