### PR TITLE
Fix wrong format verb in tests

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -345,7 +345,7 @@ func TestDecodeSizedInts(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	if answer != tab {
-		t.Fatalf("Expected %p but got %p", answer, tab)
+		t.Fatalf("Expected %#v but got %#v", answer, tab)
 	}
 }
 


### PR DESCRIPTION
Update TestDecodeSizedInts test to use `%#v` instead of `%p` when formatting structs.
