### PR TITLE
Fix readme typo on Decode method

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ type songs struct {
   Song []song
 }
 var favorites songs
-if _, err := Decode(blob, &favorites); err != nil {
+if _, err := toml.Decode(blob, &favorites); err != nil {
   log.Fatal(err)
 }
 


### PR DESCRIPTION
Corrects `Decode` to `toml.Decode`
