### PR TITLE
Support raw/multiline strings per 0.2 TOML spec.

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -15,6 +15,8 @@ const (
 	itemText
 	itemString
 	itemRawString
+	itemMultilineString
+	itemRawMultilineString
 	itemBool
 	itemInteger
 	itemFloat
@@ -369,9 +371,27 @@ func lexValue(lx *lexer) stateFn {
 		lx.emit(itemArray)
 		return lexArrayValue
 	case r == stringStart:
+		if lx.accept(stringStart) {
+			if lx.accept(stringStart) {
+				lx.ignore() // Ignore """
+				return lexMultilineString
+			}
+
+			lx.backup()
+		}
+
 		lx.ignore() // ignore the '"'
 		return lexString
 	case r == rawStringStart:
+		if lx.accept(rawStringStart) {
+			if lx.accept(rawStringStart) {
+				lx.ignore() // Ignore """
+				return lexMultilineRawString
+			}
+
+			lx.backup()
+		}
+
 		lx.ignore() // ignore the "'"
 		return lexRawString
 	case r == 't':
@@ -461,6 +481,23 @@ func lexString(lx *lexer) stateFn {
 // lexStringEscape consumes an escaped character. It assumes that the preceding
 // '\\' has already been consumed.
 func lexStringEscape(lx *lexer) stateFn {
+	return lexStringEscapeHandler(lx, lexString, lexStringUnicode)
+}
+
+// lexMultilineStringEscape consumes an escaped character. It assumes that the
+// preceding '\\' has already been consumed.
+func lexMultilineStringEscape(lx *lexer) stateFn {
+	// Handle the special case first:
+	if isNL(lx.next()) {
+		lx.next()
+		return lexMultilineString
+	} else {
+		lx.backup()
+		return lexStringEscapeHandler(lx, lexMultilineString, lexMultilineStringUnicode)
+	}
+}
+
+func lexStringEscapeHandler(lx *lexer, stringFn stateFn, unicodeFn stateFn) stateFn {
 	r := lx.next()
 	switch r {
 	case 'b':
@@ -478,9 +515,9 @@ func lexStringEscape(lx *lexer) stateFn {
 	case '/':
 		fallthrough
 	case '\\':
-		return lexString
+		return stringFn
 	case 'u':
-		return lexStringUnicode
+		return unicodeFn
 	}
 	return lx.errorf("Invalid escape character %q. Only the following "+
 		"escape characters are allowed: "+
@@ -490,6 +527,16 @@ func lexStringEscape(lx *lexer) stateFn {
 // lexStringUnicode consumes four hexadecimal digits following '\u'. It assumes
 // that the '\u' has already been consumed.
 func lexStringUnicode(lx *lexer) stateFn {
+	return lexStringUnicodeHandler(lx, lexString)
+}
+
+// lexMultilineStringUnicode consumes four hexadecimal digits following '\u'.
+// It assumes that the '\u' has already been consumed.
+func lexMultilineStringUnicode(lx *lexer) stateFn {
+	return lexStringUnicodeHandler(lx, lexMultilineString)
+}
+
+func lexStringUnicodeHandler(lx *lexer, nextFunc stateFn) stateFn {
 	var r rune
 
 	for i := 0; i < 4; i++ {
@@ -499,12 +546,38 @@ func lexStringUnicode(lx *lexer) stateFn {
 				"but got '%s' instead.", lx.current())
 		}
 	}
-	return lexString
+	return nextFunc
+}
+
+// lexMultilineString consumes the inner contents of a string. It assumes that
+// the beginning '"""' has already been consumed and ignored.
+func lexMultilineString(lx *lexer) stateFn {
+	r := lx.next()
+	switch {
+	case r == '\\':
+		return lexMultilineStringEscape
+	case r == stringEnd:
+		if lx.accept(stringEnd) {
+			if lx.accept(stringEnd) {
+				lx.backup()
+				lx.backup()
+				lx.backup()
+				lx.emit(itemMultilineString)
+				lx.next()
+				lx.next()
+				lx.next()
+				lx.ignore()
+				return lx.pop()
+			}
+
+			lx.backup()
+		}
+	}
+	return lexMultilineString
 }
 
 // lexRawString consumes a raw string. Nothing can be escaped in such a string.
 // It assumes that the beginning "'" has already been consumed and ignored.
-
 func lexRawString(lx *lexer) stateFn {
 	r := lx.next()
 	switch {
@@ -518,6 +591,32 @@ func lexRawString(lx *lexer) stateFn {
 		return lx.pop()
 	}
 	return lexRawString
+}
+
+// lexMultilineRawString consumes a raw string. Nothing can be escaped in such
+// a string. It assumes that the beginning "'" has already been consumed and
+// ignored.
+func lexMultilineRawString(lx *lexer) stateFn {
+	r := lx.next()
+	switch {
+	case r == rawStringEnd:
+		if lx.accept(rawStringEnd) {
+			if lx.accept(rawStringEnd) {
+				lx.backup()
+				lx.backup()
+				lx.backup()
+				lx.emit(itemRawMultilineString)
+				lx.next()
+				lx.next()
+				lx.next()
+				lx.ignore()
+				return lx.pop()
+			}
+
+			lx.backup()
+		}
+	}
+	return lexMultilineRawString
 }
 
 // lexNumberOrDateStart consumes either a (positive) integer, float or datetime.
@@ -730,6 +829,10 @@ func (itype itemType) String() string {
 	case itemString:
 		return "String"
 	case itemRawString:
+		return "String"
+	case itemMultilineString:
+		return "String"
+	case itemRawMultilineString:
 		return "String"
 	case itemBool:
 		return "Bool"

--- a/parse.go
+++ b/parse.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -148,8 +149,12 @@ func (p *parser) value(it item) (interface{}, tomlType) {
 	switch it.typ {
 	case itemString:
 		return p.replaceUnicode(replaceEscapes(it.val)), p.typeOfPrimitive(it)
+	case itemMultilineString:
+		return p.replaceUnicode(replaceEscapes(stripFirstNewline(stripEscapedWhitespace(it.val)))), p.typeOfPrimitive(it)
 	case itemRawString:
 		return it.val, p.typeOfPrimitive(it)
+	case itemRawMultilineString:
+		return stripFirstNewline(it.val), p.typeOfPrimitive(it)
 	case itemBool:
 		switch it.val {
 		case "true":
@@ -387,6 +392,26 @@ func replaceEscapes(s string) string {
 		"\\/", "\u002F",
 		"\\\\", "\u005C",
 	).Replace(s)
+}
+
+func stripFirstNewline(s string) string {
+	if len(s) == 0 || s[0] != '\n' {
+		return s
+	}
+
+	return s[1:len(s)]
+}
+
+func stripEscapedWhitespace(s string) string {
+	esc := strings.Split(s, "\\\n")
+
+	if len(esc) > 1 {
+		for i := 1; i < len(esc); i++ {
+			esc[i] = strings.TrimLeftFunc(esc[i], unicode.IsSpace)
+		}
+	}
+
+	return strings.Join(esc, "")
 }
 
 func (p *parser) replaceUnicode(s string) string {

--- a/type_check.go
+++ b/type_check.go
@@ -56,7 +56,11 @@ func (p *parser) typeOfPrimitive(lexItem item) tomlType {
 		return tomlDatetime
 	case itemString:
 		return tomlString
+	case itemMultilineString:
+		return tomlString
 	case itemRawString:
+		return tomlString
+	case itemRawMultilineString:
 		return tomlString
 	case itemBool:
 		return tomlBool


### PR DESCRIPTION
-   Support single-line raw strings.
  -   Based on code originally in anaxagoras/raw-strings.
-   Implement multiline strings and raw multiline strings, using """/""" and
  '''/''' per the 0.2 TOML spec.
