### PR TITLE
added support and tests for multiline string encoding closes BurntSushi/toml#64

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -478,6 +478,7 @@ func (enc *Encoder) keyEqElement(key Key, val reflect.Value) {
 		enc.eElement(val)
 	}
 	enc.newline()
+	enc.modifier = MOD_NONE //re-setting the flag for safety. shoud not strictly be necessary
 }
 
 func (enc *Encoder) writeMultiLineString(s string, raw bool) {

--- a/encode.go
+++ b/encode.go
@@ -30,6 +30,16 @@ var (
 	errAnything = errors.New("") // used in testing
 )
 
+const (
+	MOD_MULTILINE_STRING    string = "multiline_string"
+	MOD_MULTILINE_RAWSTRING string = "multiline_rawstring"
+)
+
+var validmodifiers = map[string]reflect.Kind{
+	MOD_MULTILINE_STRING:    reflect.String,
+	MOD_MULTILINE_RAWSTRING: reflect.String,
+}
+
 var quotedReplacer = strings.NewReplacer(
 	"\t", "\\t",
 	"\n", "\\n",
@@ -49,14 +59,18 @@ type Encoder struct {
 	// hasWritten is whether we have written any output to w yet.
 	hasWritten bool
 	w          *bufio.Writer
+
+	// modifiers contains a map of struct field keys with detected modifiers
+	modifiers map[string]string
 }
 
 // NewEncoder returns a TOML encoder that encodes Go values to the io.Writer
 // given. By default, a single indentation level is 2 spaces.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
-		w:      bufio.NewWriter(w),
-		Indent: "  ",
+		w:         bufio.NewWriter(w),
+		Indent:    "  ",
+		modifiers: make(map[string]string),
 	}
 }
 
@@ -341,6 +355,12 @@ func (enc *Encoder) eStruct(key Key, rv reflect.Value) {
 			if keyName == "" {
 				keyName = sft.Name
 			}
+
+			keyModifier := sft.Tag.Get("modifier")
+			if kind, ok := validmodifiers[keyModifier]; ok && sf.Kind() == kind {
+				enc.modifiers[key.add(keyName).String()] = keyModifier
+			}
+
 			enc.encode(key.add(keyName), sf)
 		}
 	}
@@ -442,8 +462,46 @@ func (enc *Encoder) keyEqElement(key Key, val reflect.Value) {
 	}
 	panicIfInvalidKey(key, false)
 	enc.wf("%s%s = ", enc.indentStr(key), key[len(key)-1])
-	enc.eElement(val)
+
+	//a modifier exists on this element, handle it with the appropriate function
+	if modifier, exists := enc.modifiers[key.String()]; exists {
+		switch modifier {
+		case MOD_MULTILINE_STRING:
+			enc.writeMultiLineString(val.String(), false)
+		case MOD_MULTILINE_RAWSTRING:
+			enc.writeMultiLineString(val.String(), true)
+		default:
+			enc.eElement(val)
+		}
+		delete(enc.modifiers, key.String())
+	} else {
+		enc.eElement(val)
+	}
 	enc.newline()
+}
+
+func (enc *Encoder) writeMultiLineString(s string, raw bool) {
+	//if there are any windows style CRLF terminations, replace them with newlines and then split
+	s = strings.Replace(s, "\r\n", "\n", -1)
+	lines := strings.Split(s, "\n")
+
+	var marker string
+	if raw {
+		marker = `'''`
+	} else {
+		marker = `"""`
+	}
+
+	enc.wf(marker) //triple quote to start multiline string
+	for _, line := range lines {
+		enc.newline() //spec: decoder must remove \n if after triple quote
+		if raw {
+			enc.wf(line)
+		} else {
+			enc.wf(quotedReplacer.Replace(line)) //quote the rest of the characters
+		}
+	}
+	enc.wf(marker)
 }
 
 func (enc *Encoder) wf(format string, v ...interface{}) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -387,6 +387,18 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 			},
 			wantError: errAnything,
 		},
+		"multiline string": {
+			input: struct {
+				Text string `modifier:"multiline_string"`
+			}{"\"Roses\" are red\n\"Violets\" are blue"},
+			wantOutput: "Text = \"\"\"\n\\\"Roses\\\" are red\n\\\"Violets\\\" are blue\"\"\"\n",
+		},
+		"multiline raw string": {
+			input: struct {
+				Text string `modifier:"multiline_rawstring"`
+			}{"\"Roses\" are red\n\"Violets\" are blue"},
+			wantOutput: "Text = '''\n\"Roses\" are red\n\"Violets\" are blue'''\n",
+		},
 	}
 	for label, test := range tests {
 		encodeExpected(t, label, test.input, test.wantOutput, test.wantError)


### PR DESCRIPTION
I would like to propose a solution to encoding multiline strings and raw multiline strings that I had raised in the issue BurntSushi/toml#64. 

The proposal is to accept a new struct tag `modifier` which can take values of `"multiline_string"` or `"multiline_rawstring"` (exported as constants `MOD_MULTILINE_STRING` and `MOD_MULTILINE_RAWSTRING`). On detecting presence of either of these modifiers, the type of the struct member is checked to confirm to `reflect.String` and then the `Key.String()` to which the modifier applies is inserted into a new map attribute of Encoder called `modifiers`. 

In the functions that actually process and emit the key/value (in this case in `keyEqElement`) we can check for presence of the key being processed currently in `modifiers` and if the modifier is `MOD_MULTILINE_STRING` or `MOD_MULTILINE_RAWSTRING`, the element is written by the new `writeMultiLineString()` function. The reason for choosing the route of using an additional encoder attribute is that `Key` is currently implemented as `[]string` which makes it difficult to store modifiers with the `Key` itself. 

The same concept can be extended to any other output modifiers if necessary even in the future. I have added tests for multiline string encoding currently in the encode_test.go file (not yet figured out the toml-test package) and still need to writeup documentation but would like to seek review of the proposal 
