### PR TITLE
fix for "panic: reflect: slice index out of range"

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -308,9 +308,8 @@ func (md *MetaData) unifySlice(data interface{}, rv reflect.Value) error {
 		return badtype("slice", data)
 	}
 	sliceLen := datav.Len()
-	if rv.IsNil() {
-		rv.Set(reflect.MakeSlice(rv.Type(), sliceLen, sliceLen))
-	}
+	rv.Set(reflect.MakeSlice(rv.Type(), sliceLen, sliceLen))
+
 	return md.unifySliceArray(datav, rv)
 }
 


### PR DESCRIPTION
This happens when you have slice in your structure, and slice is populated with some default values before calling Decode fn.

Stacktrace:
```
panic: reflect: slice index out of range

goroutine 1 [running]:
reflect.Value.Index(0x6c76e0, 0xc2080332c0, 0xd7, 0x1, 0x0, 0x0, 0x0)
	/usr/local/go/src/reflect/value.go:818 +0x149
github.com/BurntSushi/toml.(*MetaData).unifySliceArray(0xc20804c910, 0x6c6360, 0xc20801f640, 0x57, 0x6c76e0, 0xc2080332c0, 0xd7, 0x0, 0x0)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:330 +0x204
github.com/BurntSushi/toml.(*MetaData).unifySlice(0xc20804c910, 0x6c6360, 0xc20801f640, 0x6c76e0, 0xc2080332c0, 0xd7, 0x0, 0x0)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:318 +0x2d2
github.com/BurntSushi/toml.(*MetaData).unify(0xc20804c910, 0x6c6360, 0xc20801f640, 0x6c76e0, 0xc2080332c0, 0xd7, 0x0, 0x0)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:206 +0xd52
github.com/BurntSushi/toml.(*MetaData).unifyStruct(0xc20804c910, 0x6d3a40, 0xc20800b6e0, 0x784de0, 0xc2080332b0, 0xd9, 0x0, 0x0)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:252 +0x7c9
github.com/BurntSushi/toml.(*MetaData).unify(0xc20804c910, 0x6d3a40, 0xc20800b6e0, 0x784de0, 0xc2080332b0, 0xd9, 0x0, 0x0)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:200 +0xdea
github.com/BurntSushi/toml.(*MetaData).unifyStruct(0xc20804c910, 0x6d3a40, 0xc20800b650, 0x784ce0, 0xc2080332b0, 0xd9, 0x0, 0x0)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:252 +0x7c9
github.com/BurntSushi/toml.(*MetaData).unify(0xc20804c910, 0x6d3a40, 0xc20800b650, 0x784ce0, 0xc2080332b0, 0xd9, 0x0, 0x0)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:200 +0xdea
github.com/BurntSushi/toml.Decode(0xc2080c8000, 0x2b6, 0x773840, 0xc2080332b0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:114 +0x225
github.com/BurntSushi/toml.DecodeFile(0x7fffa2c70205, 0xb, 0x773840, 0xc2080332b0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/ivpusic/go/src/github.com/BurntSushi/toml/decode.go:124 +0x132
github.com/ivpusic/neo.(*Conf).Parse(0xc2080332b0, 0x7fffa2c70205, 0xb)
	/home/ivpusic/go/src/github.com/ivpusic/neo/conf.go:96 +0x10a
```