### PR TITLE
Updated link for TOML v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ representations. (There is an example of this below.)
 Spec: https://github.com/mojombo/toml
 
 Compatible with TOML version
-[v0.2.0](https://github.com/mojombo/toml/blob/master/versions/toml-v0.2.0.md)
+[v0.2.0](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.2.0.md)
 
 Documentation: http://godoc.org/github.com/BurntSushi/toml
 


### PR DESCRIPTION
The provided link to the TOML v0.2.0 spec in the README is 404.