### PR TITLE
Ignore field options (omitempty,omitzero) during Decode

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -349,6 +349,25 @@ func TestDecodeSizedInts(t *testing.T) {
 	}
 }
 
+func TestDecodeWithOmitEmpty(t *testing.T) {
+	type userpass struct {
+		User string `toml:"user"`
+		Pass string `toml:"password,omitempty"`
+	}
+	value := userpass{"Testing", "Filled"}
+	toml := `
+	user = "Testing"
+	password = "Filled"
+	`
+	var up userpass
+	if _, err := Decode(toml, &up); err != nil {
+		t.Fatal(err.Error())
+	}
+	if value != up {
+		t.Fatalf("Expected %#v but got %#v", value, up)
+	}
+}
+
 func TestUnmarshaler(t *testing.T) {
 
 	var tomlBlob = `

--- a/type_fields.go
+++ b/type_fields.go
@@ -112,6 +112,7 @@ func typeFields(t reflect.Type) []field {
 				// Record found field and index sequence.
 				if name != "" || !sf.Anonymous || ft.Kind() != reflect.Struct {
 					tagged := name != ""
+					name, _ = getOptions(name)
 					if name == "" {
 						name = sf.Name
 					}


### PR DESCRIPTION
This fixes #89. Currently the only options are `omitempty` and `omitzero`, which have no significance while decoding, so these can simply be ignored.

I thought it best to use the same `getOptions` function so this stays unified in the future (if some additional options are added later).