### PR TITLE
Panic instead of os.Exit for illegal state situations in parser

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -81,7 +81,7 @@ func (p *parser) next() item {
 }
 
 func (p *parser) bug(format string, v ...interface{}) {
-	log.Fatalf("BUG: %s\n\n", fmt.Sprintf(format, v...))
+	log.Panicf("BUG: %s\n\n", fmt.Sprintf(format, v...))
 }
 
 func (p *parser) expect(typ itemType) item {


### PR DESCRIPTION
Fixes #92