### PR TITLE
Support encoding comments in toml tag

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -424,6 +424,32 @@ name = "Rice"
 
 }
 
+func TestDecodeWithComment(t *testing.T) {
+	type elephant struct {
+		Age       int `toml:"age,Elephant age in years"`
+		TuskLen   int `toml:"tusk_length,Tusk length in cm"`
+		NWrinkles int `toml:"num_wrinkles,"`
+	}
+	e := elephant{}
+	var tomlBlob = `
+	# Hello world
+	age = 5
+
+	tusk_length = 10
+	num_wrinkles = 15
+	`
+
+	if _, err := Decode(tomlBlob, &e); err != nil {
+		log.Fatal(err)
+	}
+
+	exp := elephant{5, 10, 15}
+
+	if e != exp {
+		t.Errorf("wrong elephant: got %#v, want %#v", e, exp)
+	}
+}
+
 type menu struct {
 	Dishes map[string]dish
 }

--- a/encode.go
+++ b/encode.go
@@ -108,11 +108,11 @@ func (enc *Encoder) safeEncode(key Key, rv reflect.Value) (err error) {
 // wrapper for Encoder.encode that writes a comment out above the field.
 // panics on error like encode.
 func (enc *Encoder) encodeCommented(key Key, rv reflect.Value, comment string) {
-	format := "\n# %s\n"
+	format := "\n%s# %s\n"
 	if !enc.hasWritten {
-		format = "# %s\n"
+		format = "%s# %s\n"
 	}
-	if _, err := fmt.Fprintf(enc.w, format, comment); err != nil {
+	if _, err := fmt.Fprintf(enc.w, format, enc.indentStr(key), comment); err != nil {
 		panic(err)
 	}
 	enc.encode(key, rv)

--- a/encode_test.go
+++ b/encode_test.go
@@ -491,6 +491,25 @@ unsigned = 5
 	encodeExpected(t, "simple with omitzero, non-zero", value, expected, nil)
 }
 
+func TestEncodeWithComment(t *testing.T) {
+	type elephant struct {
+		Age       int `toml:"age,Elephant age in years"`
+		TuskLen   int `toml:"tusk_length,Tusk length in cm"`
+		NWrinkles int `toml:"num_wrinkles,"`
+	}
+
+	value := elephant{5, 62, 1000}
+
+	expected := `# Elephant age in years
+age = 5
+
+# Tusk length in cm
+tusk_length = 62
+num_wrinkles = 1000
+`
+	encodeExpected(t, "simple with encodeComment", value, expected, nil)
+}
+
 func encodeExpected(
 	t *testing.T, label string, val interface{}, wantStr string, wantErr error,
 ) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -497,15 +497,18 @@ func TestEncodeWithComment(t *testing.T) {
 		TuskLen   int `toml:"tusk_length,Tusk length in cm"`
 		NWrinkles int `toml:"num_wrinkles,"`
 	}
+	value := struct {
+		Elephant elephant `toml:"elephant"`
+	}{elephant{5, 62, 1000}}
 
-	value := elephant{5, 62, 1000}
+	expected := `[elephant]
 
-	expected := `# Elephant age in years
-age = 5
+  # Elephant age in years
+  age = 5
 
-# Tusk length in cm
-tusk_length = 62
-num_wrinkles = 1000
+  # Tusk length in cm
+  tusk_length = 62
+  num_wrinkles = 1000
 `
 	encodeExpected(t, "simple with encodeComment", value, expected, nil)
 }

--- a/type_fields.go
+++ b/type_fields.go
@@ -9,6 +9,7 @@ package toml
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -95,7 +96,7 @@ func typeFields(t reflect.Type) []field {
 				if sf.PkgPath != "" { // unexported
 					continue
 				}
-				name := sf.Tag.Get("toml")
+				name := strings.Split(sf.Tag.Get("toml"), ",")[0]
 				if name == "-" {
 					continue
 				}


### PR DESCRIPTION
Implements the feature suggested in #75. I'm not sure this is actually a good idea, but thought I'd share anyway.

A possible issue with this is that people who use comments might experience breakage if later on the library implements an option that matches their exact comment. That seems like a pretty remote possibility to me, since comments are usually partial sentences.

Another way to accomplish encoding comments would be the way encoding/xml does it, but I'm not particularly fond of that approach either tbh.
