### PR TITLE
Overwrite existing slices when unmarshaling

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -308,9 +308,7 @@ func (md *MetaData) unifySlice(data interface{}, rv reflect.Value) error {
 		return badtype("slice", data)
 	}
 	sliceLen := datav.Len()
-	if rv.IsNil() {
-		rv.Set(reflect.MakeSlice(rv.Type(), sliceLen, sliceLen))
-	}
+	rv.Set(reflect.MakeSlice(rv.Type(), sliceLen, sliceLen))
 	return md.unifySliceArray(datav, rv)
 }
 


### PR DESCRIPTION
This brings the behavior inline with that of the standard library (eg.
encoding/json). This does change the behavior when the second slice is smaller (eg. before a new slice with 1 element would have overwritten just the first element of the existing slice, now you end up with a new slice). I think this is what most users will expect though (especially since it's what `encoding/json` and the like do).

Fixes #49
Fixes #99 

Eg. the following now works (which would have produced a panic before):

```go
package main

import (
	"fmt"
	"github.com/BurntSushi/toml"
)

func main() {
	blob := []byte(`
	test = ["aaa", "bbb"]

	[[table]]
	a = "test"
	`)

	type log struct {
		A string
		B string
	}

	type config struct {
		Table []log `toml:"table"`
		Test  []string
	}

	c := new(config)

	err := toml.Unmarshal(blob, &c)
	if err != nil {
		panic(err)
	}

	blob2 := []byte(`
	test = ["ccc"]

	[[table]]
	a = "test2"

	[[table]]
	a = "test3"
	`)

	err = toml.Unmarshal(blob2, &c)
	if err != nil {
		panic(err)
	}

	fmt.Printf("%+v\n", c)
}
```
Output:
```
&{Table:[{A:test2 B:} {A:test3 B:}] Test:[ccc]}
```