### PR TITLE
Fix endless loop in table name lexing

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -272,8 +272,6 @@ func lexTableNameStart(lx *lexer) stateFn {
 		lx.ignore()
 		lx.push(lexTableNameEnd)
 		return lexValue // reuse string lexing
-	case isWhitespace(r):
-		return lexTableNameStart
 	default:
 		return lexBareTableName
 	}


### PR DESCRIPTION
lexTableNameStart returns itself without consuming any data in switch
case for whitespace.

Since TOML version v0.2.0 does not allow table name being surrounded by
whitespaces, simply dropping whitespace case solves this.

Following are examples that triggered endless loops. This commit
complains on these.

```toml
[   table1]

[table2.  ]
```