### PR TITLE
Support decoding a singular element into a slice array

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -323,6 +323,13 @@ func (md *MetaData) unifySlice(data interface{}, rv reflect.Value) error {
 	if datav.Kind() != reflect.Slice {
 		if !datav.IsValid() {
 			return nil
+		} else if _, ok := data.(map[string]interface{}); ok {
+			rv2 := reflect.MakeSlice(rv.Type(), 1, 1)
+			if err := md.unifyStruct(data, rv2.Index(0)); err != nil {
+				return err
+			}
+			rv.Set(rv2)
+			return nil
 		}
 		return badtype("slice", data)
 	}


### PR DESCRIPTION
This teaches the TOML decoder how to decode a singular element into a
slice array. If you have a type like this:

    type Config struct {
        Inputs []InputConfig `toml:"inputs"`
    }

    type InputConfig struct {
        Name string `toml:"name"`
    }

You can now specify the inputs as either a single element or an array
inside of the TOML:

    [inputs]
      name = "foobar"

This will create a singular slice with one element and decode the
mapping into the struct.

This is useful when you previously only allowed a single element and you
want to expand the config to allow multiple inputs to be selected.