### PR TITLE
fix 'panic: reflect.Value.Interface: cannot return value obtained fro…

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -478,7 +478,7 @@ func rvalue(v interface{}) reflect.Value {
 // interest to us (like encoding.TextUnmarshaler).
 func indirect(v reflect.Value) reflect.Value {
 	if v.Kind() != reflect.Ptr {
-		if v.CanAddr() {
+		if v.CanAddr() && v.CanSet() {
 			pv := v.Addr()
 			if _, ok := pv.Interface().(TextUnmarshaler); ok {
 				return pv

--- a/decode_test.go
+++ b/decode_test.go
@@ -531,11 +531,7 @@ func TestDecodeFloats(t *testing.T) {
 			continue
 		}
 		if x.N != tt.want {
-<<<<<<< HEAD
 			t.Errorf("Decode(%q): got %f; want %f", input, x.N, tt.want)
-=======
-			t.Errorf("Decode(%q): got %f; want %d", input, x.N, tt.want)
->>>>>>> fork/fix-canset-error
 		}
 	}
 }


### PR DESCRIPTION
…m unexported field or method'

This fixes a panic that would occur if a struct field used a pointer by checking to see if the element is both addressable and settable by adding a `CanSet()` check.

Prior to this, when unmarshaling a TOML config in one of my apps, I would get:

    panic: reflect.Value.Interface: cannot return value obtained from unexported field or method\

on `github.com/BurntSushi/toml/decode.go:483`
