### PR TITLE
Run .travis.yml against latest Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: go
 go:
   - 1.1
   - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6
   - tip
 install:
   - go install ./...
@@ -9,4 +13,3 @@ install:
 script:
   - export PATH="$PATH:$HOME/gopath/bin"
   - make test
-


### PR DESCRIPTION
Previously the test runner only ran against Go 1.2 and tip (Go 1.7rc1), there
are 4 versions that have been released between those.

Another approach would be to only test against the latest two releases, Go 1.5
and Go 1.6 - let me know.