### PR TITLE
Provide the ability to decode from a map

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -123,6 +123,23 @@ func Decode(data string, v interface{}) (MetaData, error) {
 	return md, md.unify(p.mapping, indirect(rv))
 }
 
+// Works like Decode but skips parsing and directly decodes the mapping to the
+// interface v. Useful if the mapping was parsed by another library or from some
+// other intermediate source.
+func DecodeMap(mapping map[string]interface{}, v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr {
+		return e("Decode of non-pointer type %s", reflect.TypeOf(v))
+	}
+	if rv.IsNil() {
+		return e("Decode of nil %s", reflect.TypeOf(v))
+	}
+	md := MetaData{
+		decoded: make(map[string]bool),
+	}
+	return md.unify(mapping, indirect(rv))
+}
+
 // DecodeFile is just like Decode, except it will automatically read the
 // contents of the file at `fpath` and decode it for you.
 func DecodeFile(fpath string, v interface{}) (MetaData, error) {


### PR DESCRIPTION
I found myself in need of mapping (decoding) a `map[string]interface{}` into a particular TOML struct. Just as your library does after first parsing the mapping from a TOML string. This use case is what https://github.com/mitchellh/mapstructure aims to address. However I have been frustrated with that library's support of various edge cases and I'm not too keen on the way the code is structured. You effectively have most of its functionality, and you seem to take a more principled approach with the unify functions. It seems a shame to keep it locked away.

The situation I had was (using Viper) I had a sub-tree of a TOML file that was already parsed as a `map[string]interface{}` but I needed to map it to some recursive struct I have. Mapstructure was unable to deal with my struct and hard to modify to get to do what I wanted (deal with embedded struct pointers and so on). I currently have to `Encode` the map to a TOML string, then `Decode` it into the struct, which is rather ugly.

This simple-minded modification of the `Decode` function provides me exactly what I need and I provide it as a proof-of-concept. I'm not sure if you want to include this as is (it would be nice to have for me). This could be turned into a separate library that supports mapping -> struct, struct -> mapping, visitor functions, etc. I think such a library that solves reflective unification of different types could have quite a few uses and might as well be solved once and for all. It could be called the Go Grand Unifier. 

Another idea would exporting the root `unify` function...