### PR TITLE
break lexBool loop on ',' to allow decoding []bool

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -840,7 +840,7 @@ func lexBool(lx *lexer) stateFn {
 	var rs []rune
 	for {
 		r := lx.next()
-		if r == eof || isWhitespace(r) || isNL(r) {
+		if r == eof || isWhitespace(r) || isNL(r) || r == ',' {
 			lx.backup()
 			break
 		}


### PR DESCRIPTION
lexBool would break on decoding `key = [true, false]`, because the loop would go up to `true,` and then miss both cases.