### PR TITLE
Fix override map element value during decode

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -918,6 +918,38 @@ func TestDecodePrimitive(t *testing.T) {
 	}
 }
 
+func TestDecodeCompositeObject(t *testing.T) {
+	type T struct {
+		B int
+		C int
+	}
+
+	for i, tt := range []struct {
+		v     interface{}
+		input string
+		want  interface{}
+	}{
+		// map
+		{&map[string]map[string]int{"a": {"b": 1, "c": 2}}, "[a]\nb = 3", &map[string]map[string]int{"a": {"b": 3, "c": 2}}},
+		{&map[string]map[string]int{"a": {}}, "[a]\nb = 3", &map[string]map[string]int{"a": {"b": 3}}},
+		{&map[string]map[string]int{}, "[a]\nb = 3", &map[string]map[string]int{"a": {"b": 3}}},
+		// struct
+		{&map[string]*T{"a": {B: 1, C: 2}}, "[a]\nB = 3", &map[string]*T{"a": {B: 3, C: 2}}},
+		{&map[string]*T{"a": {}}, "[a]\nB = 3", &map[string]*T{"a": {B: 3}}},
+		{&map[string]*T{}, "[a]\nB = 3", &map[string]*T{"a": {B: 3}}},
+	} {
+		_, err := Decode("[a]\nb = 3", tt.v)
+		if err != nil {
+			t.Errorf("[%d] Decode error: %s", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(tt.v, tt.want) {
+			t.Errorf("[%d] got %#v; want %#v", i, tt.v, tt.want)
+			continue
+		}
+	}
+}
+
 func TestDecodeErrors(t *testing.T) {
 	for _, s := range []string{
 		`x="`,


### PR DESCRIPTION
I have map, that has structures as elements.
```go
type LogConfig struct {
     Filename string  `toml:"file"`
     Level       string  `toml:"level"`
}

type Config struct {
    Loggers map[string]*LogConfig `toml:"log"`
}

fun NewConfig() *Config {
    return &Config{
         Loggers: map[string]*LogConfig {
                 "error": &LogConfig{Level: "error"},
                 "access": &LogConfig{Level: "info"},
        }
}

cfg := NewConfig()
toml.DecodeFile("config.toml", &cfg)
```

And If I do not specify the both "level and file" in config, I lose the defaults with I specify on creating Config.
 
I expected that level will keep origin value if it is not specified in config.toml
