### PR TITLE
Support maps with interface{} type keys

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -265,7 +265,7 @@ func (enc *Encoder) eMapOrStruct(key Key, rv reflect.Value) {
 
 func (enc *Encoder) eMap(key Key, rv reflect.Value) {
 	rt := rv.Type()
-	if rt.Key().Kind() != reflect.String {
+	if rt.Key().Kind() != reflect.String && rt.Key().Kind() != reflect.Interface {
 		encPanic(errNonString)
 	}
 
@@ -273,7 +273,10 @@ func (enc *Encoder) eMap(key Key, rv reflect.Value) {
 	// underneath this key first, before writing sub-structs or sub-maps.
 	var mapKeysDirect, mapKeysSub []string
 	for _, mapKey := range rv.MapKeys() {
-		k := mapKey.String()
+		k, ok := mapKey.Interface().(string)
+		if !ok {
+			encPanic(errNonString)
+		}
 		if typeIsHash(tomlTypeOfGo(rv.MapIndex(mapKey))) {
 			mapKeysSub = append(mapKeysSub, k)
 		} else {

--- a/encode_test.go
+++ b/encode_test.go
@@ -251,6 +251,17 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 			},
 			wantOutput: "b = 1\n\n[a]\n  Int = 2\n",
 		},
+		"map with interface{} key type": {
+			input: map[interface{}]interface{}{
+				"a": map[interface{}]interface{}{"b": 1},
+				"c": 2,
+			},
+			wantOutput: "c = 2\n\n[a]\n  b = 1\n",
+		},
+		"(error) map with interface{} key type, with non-string key": {
+			input:     map[interface{}]string{true: ""},
+			wantError: errNonString,
+		},
 		"nested map": {
 			input: map[string]map[string]int{
 				"a": {"b": 1},


### PR DESCRIPTION
Fixes #178 

This allows `map[interface{}]interface{}` to be encoded, _if_ each and every key can be coerced to be a `string`. See #178 for more explanation.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>