### PR TITLE
Decode primitive back to original #63

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -110,9 +110,12 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) {
 	// Special case. If we can marshal the type to text, then we used that.
 	// Basically, this prevents the encoder for handling these types as
 	// generic structs (or whatever the underlying type of a TextMarshaler is).
-	switch rv.Interface().(type) {
+	switch t := rv.Interface().(type) {
 	case time.Time, TextMarshaler:
 		enc.keyEqElement(key, rv)
+		return
+	case Primitive:
+		enc.encode(key, reflect.ValueOf(t.undecoded))
 		return
 	}
 


### PR DESCRIPTION
Should fix https://github.com/BurntSushi/toml/issues/63
Special case for toml.Primitive when Encode