### PR TITLE
Output a new line above Map

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -244,7 +244,10 @@ func (enc *Encoder) eTable(key Key, rv reflect.Value) {
 		// Output an extra newline between top-level tables.
 		// (The newline isn't written if nothing else has been written though.)
 		enc.newline()
+	} else if rv := eindirect(rv); rv.Kind() == reflect.Map {
+		enc.newline()
 	}
+
 	if len(key) > 0 {
 		enc.wf("%s[%s]", enc.indentStr(key), key.maybeQuotedAll())
 		enc.newline()


### PR DESCRIPTION
I wrote the following structs.
```
type Config struct {
    Test string
    Server ServerConfig
}

type ServerConfig struct {
    Host  string        `toml:"host"`
    Port  string        `toml:"port"`
    TestA map[string]SlaveServer
}

type SlaveServer struct {
    Weight int    `toml:"weight"`
    Ip     string `toml:"ip"`
}
```

Encode:
```
Test = "test"

[Server]
  host = "localhost"
  port = "3306"
  [Server.TestA]
    [Server.TestA.bar]
      weight = 5
      ip = "10.0.0.2"
    [Server.TestA.foo]
      weight = 1
      ip = "10.0.0.1"
```

But, this is hard to read by human.
Want:
```
Test = "test"

[Server]
  host = "localhost"
  port = "3306"

  [Server.TestA]
    [Server.TestA.bar]
      weight = 5
      ip = "10.0.0.2"
    [Server.TestA.foo]
      weight = 1
      ip = "10.0.0.1"
```

I want a new line above `Map`.
Thanks.