### PR TITLE
Add ability to encode comments with desc tag

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -377,7 +377,7 @@ func (enc *Encoder) eStruct(key Key, rv reflect.Value) {
 }
 
 func (enc *Encoder) addComment(key Key, tag reflect.StructTag) {
-	if s, ok := tag.Lookup("desc"); ok {
+	if s := tag.Get("desc"); s != "" {
 		enc.wf("%s#%s\n", enc.indentStr(key), s)
 		enc.hasWritten = false
 	}

--- a/encode.go
+++ b/encode.go
@@ -368,11 +368,19 @@ func (enc *Encoder) eStruct(key Key, rv reflect.Value) {
 				continue
 			}
 
+			enc.addComment(key.add(keyName), sft.Tag)
 			enc.encode(key.add(keyName), sf)
 		}
 	}
 	writeFields(fieldsDirect)
 	writeFields(fieldsSub)
+}
+
+func (enc *Encoder) addComment(key Key, tag reflect.StructTag) {
+	if s, ok := tag.Lookup("desc"); ok {
+		enc.wf("%s#%s\n", enc.indentStr(key), s)
+		enc.hasWritten = false
+	}
 }
 
 // tomlTypeName returns the TOML type name of the Go value's type. It is

--- a/encode.go
+++ b/encode.go
@@ -378,7 +378,7 @@ func (enc *Encoder) eStruct(key Key, rv reflect.Value) {
 
 func (enc *Encoder) addComment(key Key, tag reflect.StructTag) {
 	if s := tag.Get("desc"); s != "" {
-		enc.wf("%s#%s\n", enc.indentStr(key), s)
+		enc.wf("%s# %s\n", enc.indentStr(key), s)
 		enc.hasWritten = false
 	}
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -393,7 +393,7 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 				Float float64 `desc:"a float"`
 				Bool  bool    `desc:"a bool"`
 			}{0, 0.0, false},
-			wantOutput: "#an integer\nInt1 = 0\n#a float\nFloat = 0.0\n#a bool\nBool = false\n",
+			wantOutput: "# an integer\nInt1 = 0\n# a float\nFloat = 0.0\n# a bool\nBool = false\n",
 		},
 		"embedded struct with comments": {
 			input: struct {
@@ -405,19 +405,19 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 				Name  string `desc:"my name"`
 				Value int    `desc:"my value"`
 			}{"hello", 10}},
-			wantOutput: "#parent\n[Parent]\n  #my name\n  Name = \"hello\"\n  #my value\n  Value = 10\n",
+			wantOutput: "# parent\n[Parent]\n  # my name\n  Name = \"hello\"\n  # my value\n  Value = 10\n",
 		},
 		"slice with comments": {
 			input: struct {
 				Primes []int `desc:"prime numbers"`
 			}{[]int{1, 2, 3, 5, 7}},
-			wantOutput: "#prime numbers\nPrimes = [1, 2, 3, 5, 7]\n",
+			wantOutput: "# prime numbers\nPrimes = [1, 2, 3, 5, 7]\n",
 		},
 		"map with comments": {
 			input: struct {
 				Library map[string]interface{} `desc:"a library"`
 			}{map[string]interface{}{"name":"hello", "age": 99}},
-			wantOutput: "#a library\n[Library]\n  age = 99\n  name = \"hello\"\n",
+			wantOutput: "# a library\n[Library]\n  age = 99\n  name = \"hello\"\n",
 		},
 		"2 layer embedded struct with comments": {
 			input: struct {
@@ -427,7 +427,7 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 						} `desc:"child struct"`
 					} `desc:"parent struct"`
 			}	{},
-			wantOutput: "#parent struct\n[Parent]\n  #child struct\n  [Parent.Child]\n    #child int\n    Int = 0\n",
+			wantOutput: "# parent struct\n[Parent]\n  # child struct\n  [Parent.Child]\n    # child int\n    Int = 0\n",
 		},
 	}
 	for label, test := range tests {

--- a/encode_test.go
+++ b/encode_test.go
@@ -387,6 +387,48 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 			},
 			wantError: errAnything,
 		},
+		"simple fields with comments": {
+			input: struct {
+				Int1  int     `desc:"an integer"`
+				Float float64 `desc:"a float"`
+				Bool  bool    `desc:"a bool"`
+			}{0, 0.0, false},
+			wantOutput: "#an integer\nInt1 = 0\n#a float\nFloat = 0.0\n#a bool\nBool = false\n",
+		},
+		"embedded struct with comments": {
+			input: struct {
+				Parent struct {
+					Name  string `desc:"my name"`
+					Value int    `desc:"my value"`
+				} `desc:"parent"`
+			}{struct {
+				Name  string `desc:"my name"`
+				Value int    `desc:"my value"`
+			}{"hello", 10}},
+			wantOutput: "#parent\n[Parent]\n  #my name\n  Name = \"hello\"\n  #my value\n  Value = 10\n",
+		},
+		"slice with comments": {
+			input: struct {
+				Primes []int `desc:"prime numbers"`
+			}{[]int{1, 2, 3, 5, 7}},
+			wantOutput: "#prime numbers\nPrimes = [1, 2, 3, 5, 7]\n",
+		},
+		"map with comments": {
+			input: struct {
+				Library map[string]interface{} `desc:"a library"`
+			}{map[string]interface{}{"name":"hello", "age": 99}},
+			wantOutput: "#a library\n[Library]\n  age = 99\n  name = \"hello\"\n",
+		},
+		"2 layer embedded struct with comments": {
+			input: struct {
+					Parent struct {
+						Child struct {
+							Int int `desc:"child int"`
+						} `desc:"child struct"`
+					} `desc:"parent struct"`
+			}	{},
+			wantOutput: "#parent struct\n[Parent]\n  #child struct\n  [Parent.Child]\n    #child int\n    Int = 0\n",
+		},
 	}
 	for label, test := range tests {
 		encodeExpected(t, label, test.input, test.wantOutput, test.wantError)


### PR DESCRIPTION
Resolve issue #75 by adding a new tag 'desc' to describe variables.

example struct 
``` golang
type Person struct {
	Name string `desc:"My Name"`
	Age  int    `desc:"My Age"`
	Dog  Dog    `desc:"My dog"`
}

type Dog struct {
	Name  string `desc:"My Dog"`
	Breed string `desc:"Dog's breed"`
	Pet  Bug    `desc:"Dog's pet"`
}

type Bug struct {
	Weight float64 `desc:"in ounces"`
}
```
encodes to 
``` toml
# My Name
Name = ""
# My Age
Age = 0
# My dog
[Dog]
  # My Dog
  Name = ""
  # Dog's breed
  Breed = ""
  # Dog's pet
  [Dog.Pet]
    # in ounces
    Weight = 0.0
```