### PR TITLE
Unpack primitive data during encoding

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -146,7 +146,13 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) {
 		}
 		enc.encode(key, rv.Elem())
 	case reflect.Struct:
-		enc.eTable(key, rv)
+		switch p := rv.Interface().(type) {
+		case Primitive:
+			prv := eindirect(reflect.ValueOf(p.undecoded))
+			enc.encode(key, prv)
+		default:
+			enc.eTable(key, rv)
+		}
 	default:
 		panic(e("unsupported type for key '%s': %s", key, k))
 	}


### PR DESCRIPTION
The encoder was treating `Primitive` values as plain old structs, which was resulting in incorrect encoding. The fix here special cases handling of primitive values to extract the internal data so that it can be rendered correctly.

@praboud and I debugged this issue together.

Fixes #63.