### PR TITLE
Support all integer types

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -20,6 +20,9 @@ nowEast = 2017-06-22T16:15:21+08:00
 nowWest = 2017-06-22T02:14:36-06:00
 yesOrNo = true
 pi = 3.14
+hexNumber = 0x12345678
+octNumber = 0o1234567
+binNumber = 0b10101010
 colors = [
 	["red", "green", "blue"],
 	["cyan", "magenta", "yellow", "black"],
@@ -35,16 +38,19 @@ cauchy = "cat 2"
 		Cauchy string
 	}
 	type simple struct {
-		Age     int
-		Colors  [][]string
-		Pi      float64
-		YesOrNo bool
-		Now     time.Time
-		NowEast time.Time
-		NowWest time.Time
-		Andrew  string
-		Kait    string
-		My      map[string]cats
+		Age       int
+		HexNumber int
+		OctNumber int
+		BinNumber int
+		Colors    [][]string
+		Pi        float64
+		YesOrNo   bool
+		Now       time.Time
+		NowEast   time.Time
+		NowWest   time.Time
+		Andrew    string
+		Kait      string
+		My        map[string]cats
 	}
 
 	var val simple
@@ -66,14 +72,17 @@ cauchy = "cat 2"
 		panic(err)
 	}
 	var answer = simple{
-		Age:     250,
-		Andrew:  "gallant",
-		Kait:    "brady",
-		Now:     now,
-		NowEast: nowEast,
-		NowWest: nowWest,
-		YesOrNo: true,
-		Pi:      3.14,
+		Age:       250,
+		HexNumber: 0x12345678,
+		OctNumber: 01234567,
+		BinNumber: 0xaa,
+		Andrew:    "gallant",
+		Kait:      "brady",
+		Now:       now,
+		NowEast:   nowEast,
+		NowWest:   nowWest,
+		YesOrNo:   true,
+		Pi:        3.14,
 		Colors: [][]string{
 			{"red", "green", "blue"},
 			{"cyan", "magenta", "yellow", "black"},

--- a/parse.go
+++ b/parse.go
@@ -2,6 +2,7 @@ package toml
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -318,9 +319,12 @@ func (p *parser) value(it item) (interface{}, tomlType) {
 	panic("unreachable")
 }
 
+var re = regexp.MustCompile("^0[xbo]")
+
 // numUnderscoresOK checks whether each underscore in s is surrounded by
 // characters that are not underscores.
 func numUnderscoresOK(s string) bool {
+	s = re.ReplaceAllString(s, "")
 	accept := false
 	for _, r := range s {
 		if r == '_' {

--- a/parse.go
+++ b/parse.go
@@ -183,7 +183,16 @@ func (p *parser) value(it item) (interface{}, tomlType) {
 				it.val)
 		}
 		val := strings.Replace(it.val, "_", "", -1)
-		num, err := strconv.ParseInt(val, 10, 64)
+
+		base := 0
+		if strings.HasPrefix(val, "0o") {
+			val = strings.TrimPrefix(val, "0o")
+			base = 8
+		} else if strings.HasPrefix(val, "0b") {
+			val = strings.TrimPrefix(val, "0b")
+			base = 2
+		}
+		num, err := strconv.ParseInt(val, base, 64)
 		if err != nil {
 			// Distinguish integer values. Normally, it'd be a bug if the lexer
 			// provides an invalid integer, but it's possible that the number is


### PR DESCRIPTION
According to the TOML spec, we should be able to represent hexadecimal, octal, and binary notations. This changes add support for these notations.

I'd appreciate if you could consider taking these changes.