### PR TITLE
Encode comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 TAGS
 tags
 .*.swp
+.idea
 tomlcheck/tomlcheck
 toml.test

--- a/_examples/comments/main.go
+++ b/_examples/comments/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"github.com/troian/toml"
+	"os"
+)
+
+type config struct {
+	Val1 string `toml:"val1" comment:"test comment 1"`
+	Val2 string `toml:"val2" comment:"test comment 2\nnext line"`
+	Val3 string `toml:"val3" commented:"true"`
+	Val4 string `toml:"val4,omitempty" commented:"true"`
+}
+
+func main () {
+	var cfg config
+
+	if err := toml.NewEncoder(os.Stdout).Encode(&cfg); err != nil {
+		fmt.Println(err)
+		return
+	}
+}

--- a/type_fields.go
+++ b/type_fields.go
@@ -95,6 +95,7 @@ func typeFields(t reflect.Type) []field {
 				if sf.PkgPath != "" && !sf.Anonymous { // unexported
 					continue
 				}
+
 				opts := getOptions(sf.Tag)
 				if opts.skip {
 					continue


### PR DESCRIPTION
Encode comment tags

```go
package main

import (
	"fmt"
	"github.com/troian/toml"
	"os"
)

type config struct {
	Val1 string `toml:"val1" comment:"test comment 1"`
	Val2 string `toml:"val2" comment:"test comment 2\nnext line"`
}

func main () {
	var cfg config

	if err := toml.NewEncoder(os.Stdout).Encode(&cfg); err != nil {
		fmt.Println(err)
		return
	}
}
```
gives out

```toml
# test comment 1
val1 = ""

# test comment 2
# next line
val2 = ""
```