### PR TITLE
Document behaviour with private struct fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,6 @@ Note that a case insensitive match will be tried if an exact match can't be
 found.
 
 A working example of the above can be found in `_examples/example.{go,toml}`.
+
+**Beware**: only exported fields of structs are considered when encoding/deconding;
+private fields are silently ignored.

--- a/encode.go
+++ b/encode.go
@@ -83,6 +83,9 @@ func NewEncoder(w io.Writer) *Encoder {
 // non-struct types and nested slices containing maps or structs.
 // (e.g., [][]map[string]string is not allowed but []map[string]string is OK
 // and so is []map[string][]string.)
+//
+// Beware: due to the use of reflection, only exported keys are encoded. Non
+// exported keys are silently discarded.
 func (enc *Encoder) Encode(v interface{}) error {
 	rv := eindirect(reflect.ValueOf(v))
 	if err := enc.safeEncode(Key([]string{}), rv); err != nil {


### PR DESCRIPTION
Address #121. Added documentation in code comments
of encode.go and explicit warning in README.md.