### PR TITLE
track index relative to recursion depth in `addFields` calls

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -319,14 +319,14 @@ func (enc *Encoder) eStruct(key Key, rv reflect.Value) {
 					// tag names as though they are not
 					// anonymous, like encoding/json does.
 					if getOptions(f.Tag).name == "" {
-						addFields(t, frv, f.Index)
+						addFields(t, frv, append(start, f.Index...))
 						continue
 					}
 				case reflect.Ptr:
 					if t.Elem().Kind() == reflect.Struct &&
 						getOptions(f.Tag).name == "" {
 						if !frv.IsNil() {
-							addFields(t.Elem(), frv.Elem(), f.Index)
+							addFields(t.Elem(), frv.Elem(), append(start, f.Index...))
 						}
 						continue
 					}

--- a/encode_test.go
+++ b/encode_test.go
@@ -555,6 +555,37 @@ func TestEncodeAnonymousStructPointerField(t *testing.T) {
 	encodeExpected(t, "non-nil anonymous tagged struct pointer field", v1, expected, nil)
 }
 
+func TestEncodeNestedAnonymousStructs(t *testing.T) {
+	type A struct {	A string }
+	type B struct { B string }
+	type C struct { C string }
+	type BC struct {
+		B
+		C
+	}
+	type Outer struct {
+		A
+		BC
+	}
+
+	v := &Outer{
+		A: A{
+			A: "a",
+		},
+		BC: BC{
+			B: B{
+				B: "b",
+			},
+			C: C{
+				C: "c",
+			},
+		},
+	}
+
+	expected := "A = \"a\"\nB = \"b\"\nC = \"c\"\n"
+	encodeExpected(t, "nested anonymous untagged structs", v, expected, nil)
+}
+
 func TestEncodeIgnoredFields(t *testing.T) {
 	type simple struct {
 		Number int `toml:"-"`


### PR DESCRIPTION
Seems to fix #250 