### PR TITLE
support decode time.Duration

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -422,6 +422,14 @@ func (md *MetaData) unifyInt(data interface{}, rv reflect.Value) error {
 			panic("unreachable")
 		}
 		return nil
+	} else if d, ok := data.(string); ok {
+		if rv.Type().String() == "time.Duration" {
+			duration, err := time.ParseDuration(d)
+			if err != nil {
+				return e("value %s is invalid format for time.Duration")
+			}
+			rv.SetInt(int64(duration))
+		}
 	}
 	return badtype("integer", data)
 }


### PR DESCRIPTION
Usually, a time.Duration in string format decode to a struct, we mast do more things:

First, create time.Duration parse struct:

```go
import (
	"time"
)

type Duration struct {
	time.Duration
}

func (d *Duration) UnmarshalText(text []byte) error {
	var err error
	d.Duration, err = time.ParseDuration(string(text))
	return err
}
```
Then change config struct field for time.Duration. `time.Duration => my.Duration`.

This will cause we mast pre process config field for adapt some third library.

So create this merge request for parse time.Duration in string format. And then we don't need to create personal Duration.