### PR TITLE
support parse time.Duration

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -422,6 +422,15 @@ func (md *MetaData) unifyInt(data interface{}, rv reflect.Value) error {
 			panic("unreachable")
 		}
 		return nil
+	} else if d, ok := data.(string); ok {
+		if rv.Type().String() == "time.Duration" {
+			duration, err := time.ParseDuration(d)
+			if err != nil {
+				return e("value %s is invalid format for time.Duration")
+			}
+			rv.SetInt(int64(duration))
+		}
+		return nil
 	}
 	return badtype("integer", data)
 }

--- a/decode.go
+++ b/decode.go
@@ -429,8 +429,8 @@ func (md *MetaData) unifyInt(data interface{}, rv reflect.Value) error {
 				return e("value %s is invalid format for time.Duration")
 			}
 			rv.SetInt(int64(duration))
+			return nil
 		}
-		return nil
 	}
 	return badtype("integer", data)
 }


### PR DESCRIPTION
Usually, a time.Duration in string format decode to a struct, we must do more things:

First, create time.Duration parse struct:

```go
import (
	"time"
)

type Duration struct {
	time.Duration
}

func (d *Duration) UnmarshalText(text []byte) error {
	var err error
	d.Duration, err = time.ParseDuration(string(text))
	return err
}
```
Then change config struct field for time.Duration. `time.Duration => my.Duration`.

This will cause we must pre process config field for adapt some third library.

So create this merge request for parse time.Duration in string format. And then we don't need to create personal Duration.