### PR TITLE
Add support for base-prefixed integers: '0b', '0o', '0x'

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1166,7 +1166,7 @@ c = 001  # invalid
 		LastKey: "c",
 		Message: `Invalid integer "001": cannot have leading zeroes`,
 	}
-	if !strings.Contains(pErr.Message, `Invalid integer "001"`) ||
+	if !strings.Contains(pErr.Message, want.Message) ||
 		pErr.Line != want.Line ||
 		pErr.LastKey != want.LastKey {
 		t.Errorf("unexpected data\nhave: %#v\nwant: %#v", pErr, want)

--- a/decode_test.go
+++ b/decode_test.go
@@ -560,6 +560,11 @@ func TestDecodeInts(t *testing.T) {
 		{"1_2_3_4", 1234},
 		{"-9_223_372_036_854_775_808", math.MinInt64},
 		{"9_223_372_036_854_775_807", math.MaxInt64},
+		{"0xdead_BEEF", 0xdeadbeef},
+		{"0x12345", 0x12345},
+		{"0x0987", 0x987},
+		{"0b1101", 0xd},
+		{"0o777", 0x1ff},
 	} {
 		var x struct{ N int64 }
 		input := "n = " + tt.s
@@ -583,6 +588,7 @@ func TestDecodeFloats(t *testing.T) {
 		{"+1.0", 1},
 		{"3.1415", 3.1415},
 		{"-0.01", -0.01},
+		{"0.1", 0.1},
 		{"5e+22", 5e22},
 		{"1e6", 1e6},
 		{"-2E-2", -2e-2},
@@ -615,16 +621,23 @@ func TestDecodeMalformedNumbers(t *testing.T) {
 		{"1e2e3", "Invalid float value"},
 		{"_123", "expected value"},
 		{"123_", "surrounded by digits"},
+		{"0b0_", "surrounded by digits"},
 		{"1._23", "surrounded by digits"},
 		{"1e__23", "surrounded by digits"},
 		{"123.", "must be followed by one or more digits"},
 		{"1.e2", "must be followed by one or more digits"},
+		{"00", "cannot have leading zeroes"},
 		{"01", "cannot have leading zeroes"},
 		{"+01", "cannot have leading zeroes"},
 		{"-01", "cannot have leading zeroes"},
 		{"01.2", "cannot have leading zeroes"},
 		{"-01.2", "cannot have leading zeroes"},
 		{"+01.2", "cannot have leading zeroes"},
+		{"0x_d00d", "invalid digit following hexadecimal base designator"},
+		{"0b_0", "invalid digit following binary base designator"},
+		{"0z", "but got 'z' instead"},
+		{"+0x3", "sign cannot be used"},
+		{"-0xf00", "sign cannot be used"},
 	} {
 		t.Run(tt.s, func(t *testing.T) {
 			var x struct{ N interface{} }

--- a/lex.go
+++ b/lex.go
@@ -866,7 +866,7 @@ func lexDecimalNumberStart(lx *lexer) stateFn {
 		p := lx.peek()
 		switch p {
 		case 'b', 'o', 'x':
-			return lx.errorf("sign cannot be used with base designator")
+			return lx.errorf("cannot use sign with non-decimal numbers: '%s%c'", lx.current(), p)
 		}
 	case '.':
 		return lx.errorf("floats must start with a digit, not '.'")
@@ -878,7 +878,6 @@ func lexDecimalNumberStart(lx *lexer) stateFn {
 
 	return lx.errorf("expected a digit but got %q", r)
 }
-
 
 // lexBaseNumberOrDate differentiates between the possible values which
 // start with '0'. It assumes that before reaching this state, the initial '0'
@@ -901,19 +900,19 @@ func lexBaseNumberOrDate(lx *lexer) stateFn {
 	case 'b':
 		r = lx.peek()
 		if !isBinary(r) {
-			lx.errorf("invalid digit following binary base designator: %q", r)
+			lx.errorf("not a binary number: '%s%c'", lx.current(), r)
 		}
 		return lexBinaryInteger
 	case 'o':
 		r = lx.peek()
 		if !isOctal(r) {
-			lx.errorf("invalid digit following octal base designator: %q", r)
+			lx.errorf("not an octal number: '%s%c'", lx.current(), r)
 		}
 		return lexOctalInteger
 	case 'x':
 		r = lx.peek()
 		if !isHexadecimal(r) {
-			lx.errorf("invalid digit following hexadecimal base designator: %q", r)
+			lx.errorf("not a hexidecimal number: '%s%c'", lx.current(), r)
 		}
 		return lexHexInteger
 	}

--- a/parse.go
+++ b/parse.go
@@ -344,7 +344,7 @@ func (p *parser) value(it item) (interface{}, tomlType) {
 // numHasLeadingZero checks if this number has leading zeroes, allowing for '0',
 // +/- signs, and base prefixes.
 func numHasLeadingZero(s string) bool {
-	if len(s) > 1 && s[0] == '0' && isDigit(rune(s[1])) { // >1 to allow "0"
+	if len(s) > 1 && s[0] == '0' && isDigit(rune(s[1])) { // >1 to allow "0" and isDigit to allow 0x
 		return true
 	}
 	if len(s) > 2 && (s[0] == '-' || s[0] == '+') && s[1] == '0' {
@@ -366,11 +366,7 @@ func numUnderscoresOK(s string) bool {
 
 		// isHexadecimal is a superset of all the permissable characters
 		// surrounding an underscore.
-		if isHexadecimal(r) {
-			accept = true
-		} else {
-			accept = false;
-		}
+		accept = isHexadecimal(r)
 	}
 	return accept
 }


### PR DESCRIPTION
Added to the language in toml-lang/toml#507

Fixes: #7