### PR TITLE
Support for getting more info (line number and last key) from error when toml.Decode()

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -30,17 +30,22 @@ type parser struct {
 	implicits map[string]bool
 }
 
-type parseError string
+type ParseError struct {
+	Message string
+	Line    int
+	LastKey string
+}
 
-func (pe parseError) Error() string {
-	return string(pe)
+func (pe ParseError) Error() string {
+	return fmt.Sprintf("Near line %d (last key parsed '%s'): %s",
+		pe.Line, pe.LastKey, pe.Message)
 }
 
 func parse(data string) (p *parser, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			var ok bool
-			if err, ok = r.(parseError); ok {
+			if err, ok = r.(ParseError); ok {
 				return
 			}
 			panic(r)
@@ -66,9 +71,12 @@ func parse(data string) (p *parser, err error) {
 }
 
 func (p *parser) panicf(format string, v ...interface{}) {
-	msg := fmt.Sprintf("Near line %d (last key parsed '%s'): %s",
-		p.approxLine, p.current(), fmt.Sprintf(format, v...))
-	panic(parseError(msg))
+	msg := fmt.Sprintf(format, v...)
+	panic(ParseError{
+		Message: msg,
+		Line:    p.approxLine,
+		LastKey: p.current(),
+	})
 }
 
 func (p *parser) next() item {


### PR DESCRIPTION
Support for getting more info (line number and last key) from error when toml.Decode().
example:

```go
var tomlObject interface{}
content := "..." // toml content
_, err  := toml.Decode(content, &tomlObject)
if err != nil {
    if parseErr, ok := err.(toml.ParseError); ok {
         fmt.Printf("line number: %d, last key is %s", parseErr.Line, parseErr.LastKey)
    }
}
```