### PR TITLE
Test recent Go versions in Travis, remove unmaintained notice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: go
 go:
-  - 1.1
-  - 1.2
-  - 1.3
-  - 1.4
-  - 1.5
-  - 1.6
-  - tip
+  - '1.11'
+  #- '1.12'
+  #- '1.13'
+  #- '1.14'
+  #- '1.15'
+  - '1.16'
+  #- 'tip'
 install:
   - go install ./...
   - go get github.com/BurntSushi/toml-test

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+TOML_TESTDIR?=tests
+
 install:
 	go install ./...
 
 test: install
-	go test -v
-	toml-test toml-test-decoder
-	toml-test -encoder toml-test-encoder
+	go test -v ./...
+	toml-test -testdir="${TOML_TESTDIR}"          toml-test-decoder
+	toml-test -testdir="${TOML_TESTDIR}" -encoder toml-test-encoder
 
 fmt:
 	gofmt -w *.go */*.go

--- a/README.md
+++ b/README.md
@@ -1,24 +1,3 @@
-# THIS PROJECT IS UNMAINTAINED
-
-The last commit to this repo before writing this message occurred over two
-years ago. While it was never my intention to abandon this package, it's clear
-that I have.
-
-While many issues and PRs have piled up, the most significant short-coming
-of this library at present is that it has fallen behind the upstream TOML
-specification.
-
-Many folks are still using this package, and so long as you're happy, there's
-no pressing reason to switch to something else. With that said, it would
-probably be wise to organize around an existing alternative or fork this
-project and update it.
-
-I have no plans on handing ownership of this project over to someone else,
-unless that someone can meet an extremely high bar that inspires confidence
-that the project will be in good hands. In particular, I've had mostly poor
-(but not always) experiences with handing maintenance of a project over to
-someone else.
-
 ## TOML parser and encoder for Go with reflection
 
 TOML stands for Tom's Obvious, Minimal Language. This Go package provides a


### PR DESCRIPTION
The tests fail because the https://github.com/BurntSushi/toml-test had a
few testcases added – I'll fix that in a future PR.

Lowest version is Go 1.11 for now as that's what Debian 10/stable uses.
Might bump this to a more recent version later if needed, as that's
really quite old and e.g. the new errors in Go 1.13 might be useful.

Also don't test intermediate Go versions, as with the whole Travis "open
source credits" stuff you run out of them pretty fast and I don't feel
like mucking about with GitHub actions right now.