### PR TITLE
Fix datetime tests with timezone

### DIFF
--- a/cmd/toml-test-decoder/main.go
+++ b/cmd/toml-test-decoder/main.go
@@ -68,7 +68,7 @@ func translate(tomlData interface{}) interface{} {
 		// (If TOML ever supports tuples, we'll need this.)
 		return tag("array", typed)
 	case time.Time:
-		return tag("datetime", orig.Format("2006-01-02T15:04:05Z"))
+		return tag("datetime", orig.Format("2006-01-02T15:04:05.999999999Z07:00"))
 	case bool:
 		return tag("bool", fmt.Sprintf("%v", orig))
 	case int64:

--- a/decode_test.go
+++ b/decode_test.go
@@ -389,19 +389,20 @@ func TestDecodeDatetime(t *testing.T) {
 		},
 		{"1979-05-27", "1979-05-27T00:00:00", noTimestamp},
 	} {
-		var x struct{ D time.Time }
-		input := "d = " + tt.s
-		if _, err := Decode(input, &x); err != nil {
-			t.Errorf("Decode(%q): got error: %s", input, err)
-			continue
-		}
-		want, err := time.ParseInLocation(tt.format, tt.t, time.Local)
-		if err != nil {
-			panic(err)
-		}
-		if !x.D.Equal(want) {
-			t.Errorf("Decode(%q): got %s; want %s", input, x.D, want)
-		}
+		t.Run(tt.s, func(t *testing.T) {
+			var x struct{ D time.Time }
+			input := "d = " + tt.s
+			if _, err := Decode(input, &x); err != nil {
+				t.Fatalf("got error: %s", err)
+			}
+			want, err := time.ParseInLocation(tt.format, tt.t, time.Local)
+			if err != nil {
+				panic(err)
+			}
+			if !x.D.Equal(want) {
+				t.Errorf("got %s; want %s", x.D, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Some of the datetime tests were failing:

	Test: datetime-timezone (valid)

	Values for key 'bestdayever' don't match. Expected a value of '2017-06-06 12:34:56 -0500 -0500' but got '2017-06-06 12:34:56 +0000 UTC'.
	-------------------------------------------------------------------------------
	Test: datetime (valid)

	Values for key 'numoffset' don't match. Expected a value of '1977-06-28 12:32:00 +0000 UTC' but got '1977-06-28 07:32:00 +0000 UTC'.
	-------------------------------------------------------------------------------

Turns out this was just an error in the toml-test-decoder tool.