### PR TITLE
Detect UTF-16 files and give a more helpful error

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -389,6 +389,10 @@ func lexBareKey(lx *lexer) stateFn {
 		lx.emit(itemText)
 		return lexKeyEnd
 	default:
+		// NULL bytes probably means it's a UTF-16 file without BOM.
+		if r == 0 {
+			return lx.errorf("bare keys cannot contain %q; probably using UTF-16; TOML files must be UTF-8", r)
+		}
 		return lx.errorf("bare keys cannot contain %q", r)
 	}
 }

--- a/parse.go
+++ b/parse.go
@@ -47,6 +47,12 @@ func parse(data string) (p *parser, err error) {
 		}
 	}()
 
+	if strings.HasPrefix(data, "\xff\xfe") || strings.HasPrefix(data, "\xfe\xff") {
+		return nil, fmt.Errorf(
+			"document starts with UTF-16 byte-order-mark (BOM) 0x%x; TOML files must be UTF-8",
+			data[:2])
+	}
+
 	p = &parser{
 		mapping:   make(map[string]interface{}),
 		types:     make(map[string]tomlType),


### PR DESCRIPTION
The TOML specification states that "A TOML file must be a valid UTF-8
encoded Unicode document", but especially on Windows it's easy to mix
this up as it calls "UTF-16" just "Unicode".

Most UTF-16 files have a BOM, so detect this and error out on it. Do
this before the lexing as lexer.next() assumes UTF-8 and mangles stuff.

Some files don't have a BOM; if a file contains NULL bytes then this is
probably the second byte in the surrogate pair.