### PR TITLE
Read over BOM

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -389,10 +389,6 @@ func lexBareKey(lx *lexer) stateFn {
 		lx.emit(itemText)
 		return lexKeyEnd
 	default:
-		// NULL bytes probably means it's a UTF-16 file without BOM.
-		if r == 0 {
-			return lx.errorf("bare keys cannot contain %q; probably using UTF-16; TOML files must be UTF-8", r)
-		}
 		return lx.errorf("bare keys cannot contain %q", r)
 	}
 }


### PR DESCRIPTION
Appearantly some UTF-8 files can start with a BOM, so read over that
instead of assuming it's UTF-16. Also move the check for NULL out of the
lexer, so it can remain "UTF-8 clean"; just examine the first few bytes
instead.

Ref: https://github.com/BurntSushi/toml/issues/233#issuecomment-856659320