### PR TITLE
Better error when decoding to a map without string keys

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -270,6 +270,12 @@ func (md *MetaData) unifyStruct(mapping interface{}, rv reflect.Value) error {
 }
 
 func (md *MetaData) unifyMap(mapping interface{}, rv reflect.Value) error {
+	if k := rv.Type().Key().Kind(); k != reflect.String {
+		return fmt.Errorf(
+			"toml: cannot decode to a map with non-string key type (%s in %q)",
+			k, rv.Type())
+	}
+
 	tmap, ok := mapping.(map[string]interface{})
 	if !ok {
 		if tmap == nil {


### PR DESCRIPTION
Previously it would panic with "reflect: call of reflect.Value.SetString
on int Value", which wasn't very good.

There's already a check for this when encoding, so add one for decoding
as well.

Closes #216