### PR TITLE
Encode toml.Primitive values 

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -152,6 +152,7 @@ func DecodeReader(r io.Reader, v interface{}) (MetaData, error) {
 func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 
 	// Special case. Look for a `Primitive` value.
+	// TODO: #76 would make this superfluous after implemented.
 	if rv.Type() == reflect.TypeOf((*Primitive)(nil)).Elem() {
 		// Save the undecoded data and the key context into the primitive
 		// value.

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,7 +1,6 @@
 package toml
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"log"
@@ -1608,75 +1607,4 @@ func errorContains(have error, want string) bool {
 		return false
 	}
 	return strings.Contains(have.Error(), want)
-}
-
-type MyStruct struct {
-	Data  Primitive
-	DataA int
-	DataB string
-}
-
-func TestDecodeEncodeDecodePrimitive(t *testing.T) {
-	input := `
-Data = ["Foo","Bar"]
-DataA = 1
-DataB = "bbb"
-	`
-
-	// First pass
-	func() {
-		result := MyStruct{}
-		md, err := Decode(input, &result)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if result.DataA != 1 || result.DataB != "bbb" {
-			t.Fatalf("Unexpceted unmarshaled values. %v", result)
-		}
-
-		dataValue := []string{}
-		err = md.PrimitiveDecode(result.Data, &dataValue)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if dataValue[0] != "Foo" {
-			t.Fatalf("Unexpected value of Data")
-		}
-
-		buf := bytes.Buffer{}
-		if err := NewEncoder(&buf).Encode(result); err != nil {
-			log.Fatal(err)
-		}
-
-		input = buf.String()
-	}()
-
-	if !strings.Contains(input, "Foo") {
-		t.Fatalf("Current input does not contain Foo\n%s", input)
-	}
-
-	// Second pass
-	func() {
-		result := MyStruct{}
-		md, err := Decode(input, &result)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if result.DataA != 1 || result.DataB != "bbb" {
-			t.Fatalf("Unexpceted unmarshaled values. %v", result)
-		}
-
-		dataValue := []string{}
-		err = md.PrimitiveDecode(result.Data, &dataValue)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if dataValue[0] != "Foo" {
-			t.Fatalf("Unexpected value of Data")
-		}
-	}()
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,6 +1,7 @@
 package toml
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
@@ -1607,4 +1608,75 @@ func errorContains(have error, want string) bool {
 		return false
 	}
 	return strings.Contains(have.Error(), want)
+}
+
+type MyStruct struct {
+	Data  Primitive
+	DataA int
+	DataB string
+}
+
+func TestDecodeEncodeDecodePrimitive(t *testing.T) {
+	input := `
+Data = ["Foo","Bar"]
+DataA = 1
+DataB = "bbb"
+	`
+
+	// First pass
+	func() {
+		result := MyStruct{}
+		md, err := Decode(input, &result)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result.DataA != 1 || result.DataB != "bbb" {
+			t.Fatalf("Unexpceted unmarshaled values. %v", result)
+		}
+
+		dataValue := []string{}
+		err = md.PrimitiveDecode(result.Data, &dataValue)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if dataValue[0] != "Foo" {
+			t.Fatalf("Unexpected value of Data")
+		}
+
+		buf := bytes.Buffer{}
+		if err := NewEncoder(&buf).Encode(result); err != nil {
+			log.Fatal(err)
+		}
+
+		input = buf.String()
+	}()
+
+	if !strings.Contains(input, "Foo") {
+		t.Fatalf("Current input does not contain Foo\n%s", input)
+	}
+
+	// Second pass
+	func() {
+		result := MyStruct{}
+		md, err := Decode(input, &result)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result.DataA != 1 || result.DataB != "bbb" {
+			t.Fatalf("Unexpceted unmarshaled values. %v", result)
+		}
+
+		dataValue := []string{}
+		err = md.PrimitiveDecode(result.Data, &dataValue)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if dataValue[0] != "Foo" {
+			t.Fatalf("Unexpected value of Data")
+		}
+	}()
 }

--- a/encode.go
+++ b/encode.go
@@ -114,9 +114,12 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) {
 	// Special case. If we can marshal the type to text, then we used that.
 	// Basically, this prevents the encoder for handling these types as
 	// generic structs (or whatever the underlying type of a TextMarshaler is).
-	switch rv.Interface().(type) {
+	switch t := rv.Interface().(type) {
 	case time.Time, encoding.TextMarshaler:
 		enc.keyEqElement(key, rv)
+		return
+	case Primitive:
+		enc.encode(key, reflect.ValueOf(t.undecoded))
 		return
 	}
 

--- a/encode.go
+++ b/encode.go
@@ -118,6 +118,7 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) {
 	case time.Time, encoding.TextMarshaler:
 		enc.keyEqElement(key, rv)
 		return
+	// TODO: #76 would make this superfluous after implemented.
 	case Primitive:
 		enc.encode(key, reflect.ValueOf(t.undecoded))
 		return

--- a/encode_test.go
+++ b/encode_test.go
@@ -556,9 +556,9 @@ func TestEncodeAnonymousStructPointerField(t *testing.T) {
 }
 
 func TestEncodeNestedAnonymousStructs(t *testing.T) {
-	type A struct {	A string }
-	type B struct { B string }
-	type C struct { C string }
+	type A struct{ A string }
+	type B struct{ B string }
+	type C struct{ C string }
 	type BC struct {
 		B
 		C
@@ -593,6 +593,41 @@ func TestEncodeIgnoredFields(t *testing.T) {
 	value := simple{}
 	expected := ""
 	encodeExpected(t, "ignored field", value, expected, nil)
+}
+
+func TestEncodePrimitive(t *testing.T) {
+	type MyStruct struct {
+		Data  Primitive
+		DataA int
+		DataB string
+	}
+
+	decodeAndEncode := func(toml string) string {
+		var s MyStruct
+		_, err := Decode(toml, &s)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+		err = NewEncoder(&buf).Encode(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return buf.String()
+	}
+
+	original := `DataA = 1
+DataB = "bbb"
+Data = ["Foo", "Bar"]
+`
+	reEncoded := decodeAndEncode(decodeAndEncode(original))
+
+	if reEncoded != original {
+		t.Errorf(
+			"re-encoded not the same as original\noriginal:   %q\nre-encoded: %q",
+			original, reEncoded)
+	}
 }
 
 func encodeExpected(


### PR DESCRIPTION
`toml.Primitive` values didn't get encoded correctly, so ensure they do now.

Follow-up to #63, but with a better/clearer test case.