### PR TITLE
Improve encoding.TextMarshaler support

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -423,9 +423,21 @@ func tomlTypeOfGo(rv reflect.Value) tomlType {
 		case encoding.TextMarshaler:
 			return tomlString
 		default:
+			// Someone used a pointer receiver: we can make it work for pointer
+			// values.
+			if rv.CanAddr() {
+				_, ok := rv.Addr().Interface().(encoding.TextMarshaler)
+				if ok {
+					return tomlString
+				}
+			}
 			return tomlHash
 		}
 	default:
+		_, ok := rv.Interface().(encoding.TextMarshaler)
+		if ok {
+			return tomlString
+		}
 		encPanic(errors.New("unsupported type: " + rv.Kind().String()))
 		panic("") // Need *some* return value
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -650,6 +651,71 @@ func TestEncodeError(t *testing.T) {
 				t.Errorf("wrong error\nhave: %q\nwant: %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+type (
+	sound struct{ S string }
+	food  struct{ F []string }
+	fun   func()
+	cplx  complex128
+)
+
+// This is intentionally wrong (pointer receiver)
+func (s *sound) MarshalText() ([]byte, error) { return []byte(s.S), nil }
+func (f food) MarshalText() ([]byte, error)   { return []byte(strings.Join(f.F, ", ")), nil }
+func (f fun) MarshalText() ([]byte, error)    { return []byte("why would you do this?"), nil }
+func (c cplx) MarshalText() ([]byte, error) {
+	cplx := complex128(c)
+	return []byte(fmt.Sprintf("(%f+%fi)", real(cplx), imag(cplx))), nil
+}
+
+func TestEncodeTextMarshaler(t *testing.T) {
+	x := struct {
+		Name    string
+		Labels  map[string]string
+		Sound   sound
+		Sound2  *sound
+		Food    food
+		Food2   *food
+		Complex cplx
+		Fun     fun
+	}{
+		Name:   "Goblok",
+		Sound:  sound{"miauw"},
+		Sound2: &sound{"miauw"},
+		Labels: map[string]string{
+			"type":  "cat",
+			"color": "black",
+		},
+		Food:    food{[]string{"chicken", "fish"}},
+		Food2:   &food{[]string{"chicken", "fish"}},
+		Complex: complex(42, 666),
+		Fun:     func() { panic("x") },
+	}
+
+	var buf bytes.Buffer
+	if err := NewEncoder(&buf).Encode(x); err != nil {
+		t.Fatal(err)
+	}
+
+	want := `Name = "Goblok"
+Sound2 = "miauw"
+Food = "chicken, fish"
+Food2 = "chicken, fish"
+Complex = "(42.000000+666.000000i)"
+Fun = "why would you do this?"
+
+[Labels]
+  color = "black"
+  type = "cat"
+
+[Sound]
+  S = "miauw"
+`
+
+	if buf.String() != want {
+		t.Error("\n" + buf.String())
 	}
 }
 


### PR DESCRIPTION
There were a few minor problems/edge cases:

- In cases someone accidentally uses a pointer receiver on their
  MarshalText() implementation we can make it work at least for pointer
  types. We can't really fix it for concrete types though, but this is
  at least better. Before it was confusing because fetching the actual
  value *did* work, it just got recognized as a table/hash in
  tomlTypeOfGo() rather than a string.

  Fixes #207

- Implementing MarshalText() for types not supported by this library
  didn't work, such as complex128, but also func() or channels (why you
  would do this, beats me, but complex numbers are probably useful).

  Fixes #223