### PR TITLE
Fix panic on unclosed inline tables

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -311,10 +311,6 @@ func (p *parser) value(it item) (interface{}, tomlType) {
 		p.context = append(p.context, p.currentKey)
 		p.currentKey = ""
 		for it := p.next(); it.typ != itemInlineTableEnd; it = p.next() {
-			if it.typ != itemKeyStart {
-				p.bug("Expected key start but instead found %q, around line %d",
-					it.val, p.approxLine)
-			}
 			if it.typ == itemCommentStart {
 				p.expect(itemText)
 				continue


### PR DESCRIPTION
With this:

	x = {key = 1 #

It would trigger the p.bug call:

	if it.typ != itemKeyStart {
		p.bug("Expected key start but instead found %q, around line %d",
			it.val, p.approxLine)
	}

That's not right; an unclodes table is a user error in the TOML file,
not a bug. Just removing that fixes it.

We could also replace this with p.panicf, but the error for that is less
nice:

       have: "Near line 1 (last key parsed 'x.a'): Expected key start but instead found \"\", around line 1"

And it always worked line this for e.g. arrays just fine:

	x = [1 #