### PR TITLE
Improve support for datetime parsing and encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,9 @@ SKIP_ENCODE?=valid/inline-table-array,\
 	     valid/inline-table,\
 	     valid/nested-inline-table-array,\
 	     valid/array-table-array-string-backslash,\
-	     valid/datetime-timezone,\
-	     valid/datetime,\
 	     valid/inline-table-empty,\
 	     valid/inline-table-nest,\
-	     valid/key-escapes,\
-	     valid/spec-example-1-compact,\
-	     valid/spec-example-1
+	     valid/key-escapes
 
 install:
 	@go install ./...

--- a/cmd/toml-test-encoder/main.go
+++ b/cmd/toml-test-encoder/main.go
@@ -94,7 +94,7 @@ func untag(typed map[string]interface{}) interface{} {
 		return f
 	case "datetime":
 		v := v.(string)
-		t, err := time.Parse("2006-01-02T15:04:05Z", v)
+		t, err := time.Parse("2006-01-02T15:04:05.999999999Z07:00", v)
 		if err != nil {
 			log.Fatalf("Could not parse '%s' as a datetime: %s", v, err)
 		}

--- a/encode.go
+++ b/encode.go
@@ -165,10 +165,8 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) {
 func (enc *Encoder) eElement(rv reflect.Value) {
 	switch v := rv.Interface().(type) {
 	case time.Time:
-		// Special case time.Time as a primitive. Has to come before
-		// TextMarshaler below because time.Time implements
-		// encoding.TextMarshaler, but we need to always use UTC.
-		enc.wf(v.UTC().Format("2006-01-02T15:04:05Z"))
+		// Using TextMarshaler adds extra quotes, which we don't want.
+		enc.wf(v.Format(time.RFC3339Nano))
 		return
 	case encoding.TextMarshaler:
 		// Special case. Use text marshaler if it's available for this value.

--- a/encode_test.go
+++ b/encode_test.go
@@ -66,7 +66,7 @@ func TestEncode(t *testing.T) {
 	}
 	type NonStruct int
 
-	date := time.Date(2014, 5, 11, 20, 30, 40, 0, time.FixedZone("IST", 3600))
+	date := time.Date(2014, 5, 11, 19, 30, 40, 0, time.UTC)
 	dateStr := "2014-05-11T19:30:40Z"
 
 	tests := map[string]struct {
@@ -739,7 +739,6 @@ func encodeExpected(
 		return
 	}
 	if got := buf.String(); wantStr != got {
-		t.Errorf("%s: want\n-----\n%q\n-----\nbut got\n-----\n%q\n-----\n",
-			label, wantStr, got)
+		t.Errorf("%s\nhave: %q\nwant: %q\n", label, got, wantStr)
 	}
 }

--- a/lex.go
+++ b/lex.go
@@ -828,12 +828,12 @@ func lexDatetime(lx *lexer) stateFn {
 		return lexDatetime
 	}
 	switch r {
-	case '-', 'T', ':', '.', 'Z', '+':
+	case '-', ':', 'T', 't', ' ', '.', 'Z', 'z', '+':
 		return lexDatetime
 	}
 
 	lx.backup()
-	lx.emit(itemDatetime)
+	lx.emitTrim(itemDatetime)
 	return lx.pop()
 }
 


### PR DESCRIPTION
Added in TOML 0.5:

- Add Local Date-Time.
- Add Local Date.
- Add Local Time.
- Allow space (instead of T) to separate date and time in Date-Time.
- Clarify that at least millisecond precision expected for Date-Time and Time.

Fixes #218
Fixes #246