### PR TITLE
Update to use new toml-test, fix a few bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,19 @@
-TOML_TESTDIR?=tests
+# toml: TOML array element cannot contain a table
+# Dotted keys are not supported yet.
+SKIP_ENCODE?=valid/inline-table-nest,valid/key-dotted
 
-# TODO: these should be fixed
-SKIP_DECODE?=valid/array-table-array-string-backslash,\
-	     valid/inline-table-array,\
-	     valid/inline-table,\
-	     valid/nested-inline-table-array,\
-	     invalid/bad-utf8,\
-	     invalid/key-multiline,\
-	     invalid/inline-table-empty,\
-	     invalid/inline-table-nest,\
-	     valid/inline-table-empty,\
-	     valid/inline-table-nest
+# Dotted keys are not supported yet.
+SKIP_DECODE=valid/key-dotted
 
-SKIP_ENCODE?=valid/inline-table-array,\
-	     valid/inline-table,\
-	     valid/nested-inline-table-array,\
-	     valid/array-table-array-string-backslash,\
-	     valid/inline-table-empty,\
-	     valid/inline-table-nest,\
-	     valid/key-escapes
+# No easy way to see if this was a datetime or local datetime; we should extend
+# meta with new types for this, which seems like a good idea in any case.
+SKIP_DECODE+=,valid/datetime-local-date,valid/datetime-local-time,valid/datetime-local
+SKIP_ENCODE+=,valid/datetime-local-date,valid/datetime-local-time,valid/datetime-local
 
-install:
+all:
+	@e=0  # So it won't stop on the first command that fails.
 	@go install ./...
-
-test: install
-	@go test ./...
-	@toml-test -testdir="${TOML_TESTDIR}" -skip="${SKIP_DECODE}"          toml-test-decoder
-	@toml-test -testdir="${TOML_TESTDIR}" -skip="${SKIP_ENCODE}" -encoder toml-test-encoder
-
-fmt:
-	gofmt -w *.go */*.go
-	colcheck *.go */*.go
-
-tags:
-	find ./ -name '*.go' -print0 | xargs -0 gotags > TAGS
-
-push:
-	git push origin master
-	git push github master
-
+	@go test ./... || e=1
+	@toml-test -skip="${SKIP_DECODE}" toml-test-decoder || e=1
+	@toml-test -encoder -skip="${SKIP_ENCODE}" toml-test-encoder || e=1
+	@exit $e

--- a/cmd/toml-test-encoder/main.go
+++ b/cmd/toml-test-encoder/main.go
@@ -1,5 +1,5 @@
-// Command toml-test-encoder satisfies the toml-test interface for testing
-// TOML encoders. Namely, it accepts JSON on stdin and outputs TOML on stdout.
+// Command toml-test-encoder satisfies the toml-test interface for testing TOML
+// encoders. Namely, it accepts JSON on stdin and outputs TOML on stdout.
 package main
 
 import (
@@ -16,7 +16,6 @@ import (
 
 func init() {
 	log.SetFlags(0)
-
 	flag.Usage = usage
 	flag.Parse()
 }
@@ -24,7 +23,6 @@ func init() {
 func usage() {
 	log.Printf("Usage: %s < json-file\n", path.Base(os.Args[0]))
 	flag.PrintDefaults()
-
 	os.Exit(1)
 }
 
@@ -38,8 +36,7 @@ func main() {
 		log.Fatalf("Error decoding JSON: %s", err)
 	}
 
-	tomlData := translate(tmp)
-	if err := toml.NewEncoder(os.Stdout).Encode(tomlData); err != nil {
+	if err := toml.NewEncoder(os.Stdout).Encode(translate(tmp)); err != nil {
 		log.Fatalf("Error encoding TOML: %s", err)
 	}
 }
@@ -56,17 +53,11 @@ func translate(typedJson interface{}) interface{} {
 		}
 		return m
 	case []interface{}:
-		tabArray := make([]map[string]interface{}, len(v))
+		a := make([]interface{}, len(v))
 		for i := range v {
-			if m, ok := translate(v[i]).(map[string]interface{}); ok {
-				tabArray[i] = m
-			} else {
-				log.Fatalf("JSON arrays may only contain objects. This " +
-					"corresponds to only tables being allowed in " +
-					"TOML table arrays.")
-			}
+			a[i] = translate(v[i])
 		}
-		return tabArray
+		return a
 	}
 	log.Fatalf("Unrecognized JSON format '%T'.", typedJson)
 	panic("unreachable")
@@ -108,18 +99,6 @@ func untag(typed map[string]interface{}) interface{} {
 			return false
 		}
 		log.Fatalf("Could not parse '%s' as a boolean.", v)
-	case "array":
-		v := v.([]interface{})
-		array := make([]interface{}, len(v))
-		for i := range v {
-			if m, ok := v[i].(map[string]interface{}); ok {
-				array[i] = untag(m)
-			} else {
-				log.Fatalf("Arrays may only contain other arrays or "+
-					"primitive values, but found a '%T'.", m)
-			}
-		}
-		return array
 	}
 	log.Fatalf("Unrecognized tag type '%s'.", t)
 	panic("unreachable")

--- a/decode_meta.go
+++ b/decode_meta.go
@@ -41,8 +41,8 @@ func (md *MetaData) IsDefined(key ...string) bool {
 
 // Type returns a string representation of the type of the key specified.
 //
-// Type will return the empty string if given an empty key or a key that
-// does not exist. Keys are case sensitive.
+// Type will return the empty string if given an empty key or a key that does
+// not exist. Keys are case sensitive.
 func (md *MetaData) Type(key ...string) string {
 	fullkey := strings.Join(key, ".")
 	if typ, ok := md.types[fullkey]; ok {
@@ -68,6 +68,9 @@ func (k Key) maybeQuotedAll() string {
 }
 
 func (k Key) maybeQuoted(i int) string {
+	if k[i] == "" {
+		return `""`
+	}
 	quote := false
 	for _, c := range k[i] {
 		if !isBareKeyChar(c) {
@@ -76,7 +79,7 @@ func (k Key) maybeQuoted(i int) string {
 		}
 	}
 	if quote {
-		return "\"" + strings.Replace(k[i], "\"", "\\\"", -1) + "\""
+		return `"` + quotedReplacer.Replace(k[i]) + `"`
 	}
 	return k[i]
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -1031,9 +1031,10 @@ func TestDecodeErrors(t *testing.T) {
 		{"x = \n", "expected value but found '\\n' instead", true},
 
 		// Cases found by fuzzing in #155 and #239
-		{`""` + "\ufffd", "expected key separator", false},                            // used to panic with index out of range
-		{`x="""`, "unexpected EOF", true},                                             // used to hang
-		{`x = [{ key = 42 #`, "expected a comma or an inline table terminator", true}, // panic
+		{`""` + "\ufffd", "invalid UTF-8", false},
+		{`""=` + "\ufffd", "invalid UTF-8", false},
+		{`x="""`, "unexpected EOF", true},
+		{`x = [{ key = 42 #`, "expected a comma or an inline table terminator", true},
 		{`x = {a = 42 #`, "expected a comma or an inline table terminator '}', but got end of file instead", true},
 		{`x = [42 #`, "expected a comma or array terminator ']', but got end of file instead", false},
 

--- a/parse.go
+++ b/parse.go
@@ -59,6 +59,7 @@ func parse(data string) (p *parser, err error) {
 	if strings.HasPrefix(data, "\xff\xfe") || strings.HasPrefix(data, "\xfe\xff") {
 		data = data[2:]
 	}
+
 	// Examine first few bytes for NULL bytes; this probably means it's a UTF-16
 	// file (second byte in surrogate pair being NULL). Again, do this here to
 	// avoid having to deal with UTF-8/16 stuff in the lexer.
@@ -99,6 +100,7 @@ func (p *parser) panicf(format string, v ...interface{}) {
 
 func (p *parser) next() item {
 	it := p.lx.nextItem()
+	//fmt.Printf("ITEM %-18s line %-3d → %q\n", it.typ, it.line, it.val)
 	if it.typ == itemError {
 		p.panicf("%s", it.val)
 	}


### PR DESCRIPTION
Update to use the new toml-test from
https://github.com/BurntSushi/toml-test/pull/69

Turns out quite a few failures were just because those tests were
broken. Do'h.

And fix a few minor issues:

- nan and inf got encoded as "NaN" and "Inf".
- Detect invalid UTF-8 and error out.
- Don't allow keys as triple-quoted strings: """ key """ = "foo"
- Allow encoding blank keys ("" = 1) and escapes in keys ("\n" = 1).
- Expand string quoting with \b and \f, and other control characters as
  \u...
- Allow multiline strings to end with the quote character: """v""""

The toml-test tests will fail because of a catch-22: the toml-test needs
this version of the toml library to work for the fix in the lexer for
the multiline strings.