### PR TITLE
Implement dotted keys

### DIFF
--- a/COMPATIBLE
+++ b/COMPATIBLE
@@ -1,3 +1,1 @@
-Compatible with TOML version
-[v0.4.0](https://github.com/toml-lang/toml/blob/v0.4.0/versions/en/toml-v0.4.0.md)
-
+Compatible with TOML version [v1.0.0](https://toml.io/en/v1.0.0).

--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ packages. This package also supports the `encoding.TextUnmarshaler` and
 `encoding.TextMarshaler` interfaces so that you can define custom data
 representations. (There is an example of this below.)
 
-TOML specification: https://toml.io
-
-Compatible with TOML version [v0.4.0](https://toml.io/en/v0.4.0); support for
-more recent versions (0.5, 1.0) is forthcoming.
+Compatible with TOML version [v1.0.0](https://toml.io/en/v1.0.0).
 
 Documentation: https://pkg.go.dev/github.com/BurntSushi/toml
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,7 +1,6 @@
 package toml
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -713,61 +712,4 @@ func errorContains(have error, want string) bool {
 		return false
 	}
 	return strings.Contains(have.Error(), want)
-}
-
-func TestDecodeDottedKey(t *testing.T) {
-	tests := []struct {
-		in      string
-		want    string
-		wantErr string
-	}{
-		// Bare key
-		{`a.b=1`, `{"a":{"b":1}}`, ``},
-		{` a . b = 1`, `{"a":{"b":1}}`, ``},
-		{" \t  a   \t  .   \t   b  \t = 1", `{"a":{"b":1}}`, ``},
-		// Quoted key
-		{`"a"."b"=1`, `{"a":{"b":1}}`, ``},
-		{` "a" . "b" = 1`, `{"a":{"b":1}}`, ``},
-		{" \t  'a'   \t  .   \t   'b'  \t = 1", `{"a":{"b":1}}`, ``},
-		// Bare + quoted
-		{`a."b"=1`, `{"a":{"b":1}}`, ``},
-		{` a . "b" = 1`, `{"a":{"b":1}}`, ``},
-		{" \t  a   \t  .   \t   'b'  \t = 1", `{"a":{"b":1}}`, ``},
-		// Quoted + bare
-		{`"a".b=1`, `{"a":{"b":1}}`, ``},
-		{` "a" . b = 1`, `{"a":{"b":1}}`, ``},
-		{" \t  'a'   \t  .   \t   b  \t = 1", `{"a":{"b":1}}`, ``},
-		// Inside a table.
-		{"[a.b]\nc=1", `{"a":{"b":{"c":1}}}`, ``},
-		{"[a.b.c]\nc=1", `{"a":{"b":{"c":{"c":1}}}}`, ``},
-		{"[[a.b]]\nc=1", `{"a":{"b":[{"c":1}]}}`, ``},
-		{"[a.b]\nc.d=1", `{"a":{"b":{"c":{"d":1}}}}`, ``},
-		{"[a.b.c.d]\ne.f.g.h=1", `{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":1}}}}}}}}`, ``},
-		{"[[a.b.x.y]]\nc.d.e.f=1", `{"a":{"b":{"x":{"y":[{"c":{"d":{"e":{"f":1}}}}]}}}}`, ``},
-
-		// Multiple values on the same key
-		{"a.b=1\na.c=2\na.d=[3]", `{"a":{"b":1,"c":2,"d":[3]}}`, ``},
-
-		// Inline table.
-		//{`a={b.c=1}`, ``, ``},
-	}
-
-	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
-			var s interface{}
-			_, err := Decode(tt.in, &s)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			j, _ := json.Marshal(s)
-			have := string(j)
-
-			//if have := fmt.Sprintf("%v", s); have != tt.want {
-			if have != tt.want {
-				j, _ := json.MarshalIndent(s, "", "  ")
-				t.Errorf("\nhave: %s\nwant: %s\n\nhave indented:\n%s", have, tt.want, j)
-			}
-		})
-	}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,6 +1,7 @@
 package toml
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -42,6 +43,7 @@ func TestDecodeFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	have := fmt.Sprintf("%v %v %v", i, meta.Keys(), meta.Type("a"))
 	want := "{42} [a] Integer"
 	if have != want {
@@ -711,4 +713,61 @@ func errorContains(have error, want string) bool {
 		return false
 	}
 	return strings.Contains(have.Error(), want)
+}
+
+func TestDecodeDottedKey(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr string
+	}{
+		// Bare key
+		{`a.b=1`, `{"a":{"b":1}}`, ``},
+		{` a . b = 1`, `{"a":{"b":1}}`, ``},
+		{" \t  a   \t  .   \t   b  \t = 1", `{"a":{"b":1}}`, ``},
+		// Quoted key
+		{`"a"."b"=1`, `{"a":{"b":1}}`, ``},
+		{` "a" . "b" = 1`, `{"a":{"b":1}}`, ``},
+		{" \t  'a'   \t  .   \t   'b'  \t = 1", `{"a":{"b":1}}`, ``},
+		// Bare + quoted
+		{`a."b"=1`, `{"a":{"b":1}}`, ``},
+		{` a . "b" = 1`, `{"a":{"b":1}}`, ``},
+		{" \t  a   \t  .   \t   'b'  \t = 1", `{"a":{"b":1}}`, ``},
+		// Quoted + bare
+		{`"a".b=1`, `{"a":{"b":1}}`, ``},
+		{` "a" . b = 1`, `{"a":{"b":1}}`, ``},
+		{" \t  'a'   \t  .   \t   b  \t = 1", `{"a":{"b":1}}`, ``},
+		// Inside a table.
+		{"[a.b]\nc=1", `{"a":{"b":{"c":1}}}`, ``},
+		{"[a.b.c]\nc=1", `{"a":{"b":{"c":{"c":1}}}}`, ``},
+		{"[[a.b]]\nc=1", `{"a":{"b":[{"c":1}]}}`, ``},
+		{"[a.b]\nc.d=1", `{"a":{"b":{"c":{"d":1}}}}`, ``},
+		{"[a.b.c.d]\ne.f.g.h=1", `{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":1}}}}}}}}`, ``},
+		{"[[a.b.x.y]]\nc.d.e.f=1", `{"a":{"b":{"x":{"y":[{"c":{"d":{"e":{"f":1}}}}]}}}}`, ``},
+
+		// Multiple values on the same key
+		{"a.b=1\na.c=2\na.d=[3]", `{"a":{"b":1,"c":2,"d":[3]}}`, ``},
+
+		// Inline table.
+		//{`a={b.c=1}`, ``, ``},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			var s interface{}
+			_, err := Decode(tt.in, &s)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			j, _ := json.Marshal(s)
+			have := string(j)
+
+			//if have := fmt.Sprintf("%v", s); have != tt.want {
+			if have != tt.want {
+				j, _ := json.MarshalIndent(s, "", "  ")
+				t.Errorf("\nhave: %s\nwant: %s\n\nhave indented:\n%s", have, tt.want, j)
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/BurntSushi/toml
 
 go 1.13
 
-require github.com/BurntSushi/toml-test v0.1.1-0.20210620192437-de01089bbf76
+require github.com/BurntSushi/toml-test v0.1.1-0.20210621044449-d531a008d555

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.2-0.20210614224209-34d990aa228d/go.mod h1:2QZjSXA5e+XyFeCAxxtL8Z4StYUsTquL8ODGPR3C3MA=
-github.com/BurntSushi/toml-test v0.1.1-0.20210620192437-de01089bbf76 h1:DXhME0XxteaM9BJ3zRPDAfNAW5hW0unQhkCxme8K0ms=
+github.com/BurntSushi/toml v0.3.2-0.20210621044154-20a94d639b8e/go.mod h1:t4zg8TkHfP16Vb3x4WKIw7zVYMit5QFtPEO8lOWxzTg=
 github.com/BurntSushi/toml-test v0.1.1-0.20210620192437-de01089bbf76/go.mod h1:P/PrhmZ37t5llHfDuiouWXtFgqOoQ12SAh9j6EjrBR4=
+github.com/BurntSushi/toml-test v0.1.1-0.20210621044449-d531a008d555 h1:oNF2vOuH05dfefEw1E/x5wf6LRu98Wb9dzITyLYfrhc=
+github.com/BurntSushi/toml-test v0.1.1-0.20210621044449-d531a008d555/go.mod h1:UAIt+Eo8itMZAAgImXkPGDMYsT1SsJkVdB5TuONl86A=
 zgo.at/zli v0.0.0-20210619044753-e7020a328e59/go.mod h1:HLAc12TjNGT+VRXr76JnsNE3pbooQtwKWhX+RlDjQ2Y=

--- a/parse.go
+++ b/parse.go
@@ -14,20 +14,11 @@ type parser struct {
 	types   map[string]tomlType
 	lx      *lexer
 
-	// A list of keys in the order that they appear in the TOML data.
-	ordered []Key
-
-	// the full key for the current hash in scope
-	context Key
-
-	// the base key name for everything except hashes
-	currentKey string
-
-	// rough approximation of line number
-	approxLine int
-
-	// A map of 'key.group.names' to whether they were created implicitly.
-	implicits map[string]bool
+	ordered    []Key           // List of keys in the order that they appear in the TOML data.
+	context    Key             // Full key for the current hash in scope.
+	currentKey string          // Base key name for everything except hashes.
+	approxLine int             // Rough approximation of line number
+	implicits  map[string]bool // Record implied keys (e.g. 'key.group.names').
 }
 
 // ParseError is used when a file can't be parsed: for example invalid integer
@@ -125,10 +116,10 @@ func (p *parser) assertEqual(expected, got itemType) {
 
 func (p *parser) topLevel(item item) {
 	switch item.typ {
-	case itemCommentStart:
+	case itemCommentStart: // # ..
 		p.approxLine = item.line
 		p.expect(itemText)
-	case itemTableStart:
+	case itemTableStart: // [ .. ]
 		name := p.next()
 		p.approxLine = name.line
 
@@ -138,10 +129,10 @@ func (p *parser) topLevel(item item) {
 		}
 		p.assertEqual(itemTableEnd, name.typ)
 
-		p.establishContext(key, false)
+		p.addContext(key, false)
 		p.setType("", tomlHash)
 		p.ordered = append(p.ordered, key)
-	case itemArrayTableStart:
+	case itemArrayTableStart: // [[ .. ]]
 		name := p.next()
 		p.approxLine = name.line
 
@@ -151,36 +142,37 @@ func (p *parser) topLevel(item item) {
 		}
 		p.assertEqual(itemArrayTableEnd, name.typ)
 
-		p.establishContext(key, true)
+		p.addContext(key, true)
 		p.setType("", tomlArrayHash)
 		p.ordered = append(p.ordered, key)
-	case itemKeyStart:
-		name := p.next()
-		p.approxLine = name.line
-
+	case itemKeyStart: // key = ..
+		outerContext := p.context
+		/// Read all the key parts (e.g. 'a' and 'b' in 'a.b')
+		k := p.next()
+		p.approxLine = k.line
 		var key Key
-		for ; name.typ != itemKeyEnd && name.typ != itemEOF; name = p.next() {
-			key = append(key, p.keyString(name))
+		for ; k.typ != itemKeyEnd && k.typ != itemEOF; k = p.next() {
+			key = append(key, p.keyString(k))
 		}
-		p.assertEqual(itemKeyEnd, name.typ)
+		p.assertEqual(itemKeyEnd, k.typ)
 
+		/// The current key is the last part.
 		p.currentKey = key[len(key)-1]
-		if len(key) > 1 {
-			for i := range key[:len(key)-1] {
-				app := append(p.context, key[i:i+1]...)
-				p.addImplicit(app)
-				p.establishContext(app, false)
-			}
+
+		/// All the other parts (if any) are the context; need to set each part
+		/// as implicit.
+		context := key[:len(key)-1]
+		for i := range context {
+			p.addImplicitContext(append(p.context, context[i:i+1]...))
 		}
 
-		val, typ := p.value(p.next())
+		/// Set value.
+		val, typ := p.value(p.next(), false)
 		p.set(p.currentKey, val, typ)
 		p.ordered = append(p.ordered, p.context.add(p.currentKey))
 
-		if len(key) > 1 {
-			p.context = p.context[:len(key)-2]
-		}
-
+		/// Remove the context we added (preserving any context from [tbl] lines).
+		p.context = outerContext
 		p.currentKey = ""
 	default:
 		p.bug("Unexpected type at top level: %s", item.typ)
@@ -194,12 +186,12 @@ func (p *parser) keyString(it item) string {
 		return it.val
 	case itemString, itemMultilineString,
 		itemRawString, itemRawMultilineString:
-		s, _ := p.value(it)
+		s, _ := p.value(it, false)
 		return s.(string)
 	default:
 		p.bug("Unexpected key type: %s", it.typ)
-		panic("unreachable")
 	}
+	panic("unreachable")
 }
 
 var datetimeRepl = strings.NewReplacer(
@@ -209,161 +201,198 @@ var datetimeRepl = strings.NewReplacer(
 
 // value translates an expected value from the lexer into a Go value wrapped
 // as an empty interface.
-func (p *parser) value(it item) (interface{}, tomlType) {
+func (p *parser) value(it item, parentIsArray bool) (interface{}, tomlType) {
 	switch it.typ {
 	case itemString:
 		return p.replaceEscapes(it.val), p.typeOfPrimitive(it)
 	case itemMultilineString:
-		trimmed := stripFirstNewline(stripEscapedNewlines(it.val))
-		return p.replaceEscapes(trimmed), p.typeOfPrimitive(it)
+		return p.replaceEscapes(stripFirstNewline(stripEscapedNewlines(it.val))), p.typeOfPrimitive(it)
 	case itemRawString:
 		return it.val, p.typeOfPrimitive(it)
 	case itemRawMultilineString:
 		return stripFirstNewline(it.val), p.typeOfPrimitive(it)
+	case itemInteger:
+		return p.valueInteger(it)
+	case itemFloat:
+		return p.valueFloat(it)
 	case itemBool:
 		switch it.val {
 		case "true":
 			return true, p.typeOfPrimitive(it)
 		case "false":
 			return false, p.typeOfPrimitive(it)
+		default:
+			p.bug("Expected boolean value, but got '%s'.", it.val)
 		}
-		p.bug("Expected boolean value, but got '%s'.", it.val)
-	case itemInteger:
-		if !numUnderscoresOK(it.val) {
-			p.panicf("Invalid integer %q: underscores must be surrounded by digits",
-				it.val)
-		}
-		if numHasLeadingZero(it.val) {
-			p.panicf("Invalid integer %q: cannot have leading zeroes", it.val)
-		}
-
-		num, err := strconv.ParseInt(it.val, 0, 64)
-		if err != nil {
-			// Distinguish integer values. Normally, it'd be a bug if the lexer
-			// provides an invalid integer, but it's possible that the number is
-			// out of range of valid values (which the lexer cannot determine).
-			// So mark the former as a bug but the latter as a legitimate user
-			// error.
-			if e, ok := err.(*strconv.NumError); ok &&
-				e.Err == strconv.ErrRange {
-
-				p.panicf("Integer '%s' is out of the range of 64-bit "+
-					"signed integers.", it.val)
-			} else {
-				p.bug("Expected integer value, but got '%s'.", it.val)
-			}
-		}
-		return num, p.typeOfPrimitive(it)
-	case itemFloat:
-		parts := strings.FieldsFunc(it.val, func(r rune) bool {
-			switch r {
-			case '.', 'e', 'E':
-				return true
-			}
-			return false
-		})
-		for _, part := range parts {
-			if !numUnderscoresOK(part) {
-				p.panicf("Invalid float %q: underscores must be surrounded by digits", it.val)
-			}
-		}
-		if len(parts) > 0 && numHasLeadingZero(parts[0]) {
-			p.panicf("Invalid float %q: cannot have leading zeroes", it.val)
-		}
-		if !numPeriodsOK(it.val) {
-			// As a special case, numbers like '123.' or '1.e2',
-			// which are valid as far as Go/strconv are concerned,
-			// must be rejected because TOML says that a fractional
-			// part consists of '.' followed by 1+ digits.
-			p.panicf("Invalid float %q: '.' must be followed by one or more digits", it.val)
-		}
-		val := strings.Replace(it.val, "_", "", -1)
-		if val == "+nan" || val == "-nan" { // Go doesn't support this, but TOML spec does.
-			val = "nan"
-		}
-		num, err := strconv.ParseFloat(val, 64)
-		if err != nil {
-			if e, ok := err.(*strconv.NumError); ok && e.Err == strconv.ErrRange {
-				p.panicf("Float '%s' is out of the range of 64-bit IEEE-754 floating-point numbers.", it.val)
-			} else {
-				p.panicf("Invalid float value: %q", it.val)
-			}
-		}
-		return num, p.typeOfPrimitive(it)
 	case itemDatetime:
-		it.val = datetimeRepl.Replace(it.val)
-
-		var (
-			t   time.Time
-			ok  bool
-			err error
-		)
-		for _, format := range []string{
-			time.RFC3339Nano,
-			"2006-01-02T15:04:05.999999999",
-			"2006-01-02",
-			"15:04:05.999999999",
-		} {
-			t, err = time.ParseInLocation(format, it.val, time.Local)
-			if err == nil {
-				ok = true
-				break
-			}
-		}
-		if !ok {
-			p.panicf("Invalid TOML Datetime: %q.", it.val)
-		}
-		return t, p.typeOfPrimitive(it)
+		return p.valueDatetime(it)
 	case itemArray:
-		array := make([]interface{}, 0)
-		types := make([]tomlType, 0)
-
-		for it = p.next(); it.typ != itemArrayEnd; it = p.next() {
-			if it.typ == itemCommentStart {
-				p.expect(itemText)
-				continue
-			}
-
-			val, typ := p.value(it)
-			array = append(array, val)
-			types = append(types, typ)
-		}
-		return array, p.typeOfArray(types)
+		return p.valueArray(it)
 	case itemInlineTableStart:
-		var (
-			hash         = make(map[string]interface{})
-			outerContext = p.context
-			outerKey     = p.currentKey
-		)
-
-		p.context = append(p.context, p.currentKey)
-		p.currentKey = ""
-		for it := p.next(); it.typ != itemInlineTableEnd; it = p.next() {
-			if it.typ == itemCommentStart {
-				p.expect(itemText)
-				continue
-			}
-
-			// retrieve key
-			k := p.next()
-			_ = p.next() // XXX read KeyEnd; temporary
-			p.approxLine = k.line
-			kname := p.keyString(k)
-
-			// retrieve value
-			p.currentKey = kname
-			val, typ := p.value(p.next())
-			// make sure we keep metadata up to date
-			p.setType(kname, typ)
-			p.ordered = append(p.ordered, p.context.add(p.currentKey))
-			hash[kname] = val
-		}
-		p.context = outerContext
-		p.currentKey = outerKey
-		return hash, tomlHash
+		return p.valueInlineTable(it, parentIsArray)
+	default:
+		p.bug("Unexpected value type: %s", it.typ)
 	}
-	p.bug("Unexpected value type: %s", it.typ)
 	panic("unreachable")
+}
+
+func (p *parser) valueInteger(it item) (interface{}, tomlType) {
+	if !numUnderscoresOK(it.val) {
+		p.panicf("Invalid integer %q: underscores must be surrounded by digits", it.val)
+	}
+	if numHasLeadingZero(it.val) {
+		p.panicf("Invalid integer %q: cannot have leading zeroes", it.val)
+	}
+
+	num, err := strconv.ParseInt(it.val, 0, 64)
+	if err != nil {
+		// Distinguish integer values. Normally, it'd be a bug if the lexer
+		// provides an invalid integer, but it's possible that the number is
+		// out of range of valid values (which the lexer cannot determine).
+		// So mark the former as a bug but the latter as a legitimate user
+		// error.
+		if e, ok := err.(*strconv.NumError); ok && e.Err == strconv.ErrRange {
+			p.panicf("Integer '%s' is out of the range of 64-bit signed integers.", it.val)
+		} else {
+			p.bug("Expected integer value, but got '%s'.", it.val)
+		}
+	}
+	return num, p.typeOfPrimitive(it)
+}
+
+func (p *parser) valueFloat(it item) (interface{}, tomlType) {
+	parts := strings.FieldsFunc(it.val, func(r rune) bool {
+		switch r {
+		case '.', 'e', 'E':
+			return true
+		}
+		return false
+	})
+	for _, part := range parts {
+		if !numUnderscoresOK(part) {
+			p.panicf("Invalid float %q: underscores must be surrounded by digits", it.val)
+		}
+	}
+	if len(parts) > 0 && numHasLeadingZero(parts[0]) {
+		p.panicf("Invalid float %q: cannot have leading zeroes", it.val)
+	}
+	if !numPeriodsOK(it.val) {
+		// As a special case, numbers like '123.' or '1.e2',
+		// which are valid as far as Go/strconv are concerned,
+		// must be rejected because TOML says that a fractional
+		// part consists of '.' followed by 1+ digits.
+		p.panicf("Invalid float %q: '.' must be followed by one or more digits", it.val)
+	}
+	val := strings.Replace(it.val, "_", "", -1)
+	if val == "+nan" || val == "-nan" { // Go doesn't support this, but TOML spec does.
+		val = "nan"
+	}
+	num, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok && e.Err == strconv.ErrRange {
+			p.panicf("Float '%s' is out of the range of 64-bit IEEE-754 floating-point numbers.", it.val)
+		} else {
+			p.panicf("Invalid float value: %q", it.val)
+		}
+	}
+	return num, p.typeOfPrimitive(it)
+}
+
+func (p *parser) valueDatetime(it item) (interface{}, tomlType) {
+	it.val = datetimeRepl.Replace(it.val)
+	var (
+		t   time.Time
+		ok  bool
+		err error
+	)
+	for _, format := range []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02",
+		"15:04:05.999999999",
+	} {
+		t, err = time.ParseInLocation(format, it.val, time.Local)
+		if err == nil {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		p.panicf("Invalid TOML Datetime: %q.", it.val)
+	}
+	return t, p.typeOfPrimitive(it)
+}
+
+func (p *parser) valueArray(it item) (interface{}, tomlType) {
+	array := make([]interface{}, 0)
+	types := make([]tomlType, 0)
+
+	for it = p.next(); it.typ != itemArrayEnd; it = p.next() {
+		if it.typ == itemCommentStart {
+			p.expect(itemText)
+			continue
+		}
+
+		val, typ := p.value(it, true)
+		array = append(array, val)
+		types = append(types, typ)
+	}
+	return array, p.typeOfArray(types)
+
+}
+
+func (p *parser) valueInlineTable(it item, parentIsArray bool) (interface{}, tomlType) {
+	var (
+		hash         = make(map[string]interface{})
+		outerContext = p.context
+		outerKey     = p.currentKey
+	)
+
+	p.context = append(p.context, p.currentKey)
+	prevContext := p.context
+	p.currentKey = ""
+
+	p.addImplicit(p.context)
+	p.addContext(p.context, parentIsArray)
+
+	/// Loop over all table key/value pairs.
+	for it := p.next(); it.typ != itemInlineTableEnd; it = p.next() {
+		if it.typ == itemCommentStart {
+			p.expect(itemText)
+			continue
+		}
+
+		/// Read all key parts.
+		k := p.next()
+		p.approxLine = k.line
+		var key Key
+		for ; k.typ != itemKeyEnd && k.typ != itemEOF; k = p.next() {
+			key = append(key, p.keyString(k))
+		}
+		p.assertEqual(itemKeyEnd, k.typ)
+
+		/// The current key is the last part.
+		p.currentKey = key[len(key)-1]
+
+		/// All the other parts (if any) are the context; need to set each part
+		/// as implicit.
+		context := key[:len(key)-1]
+		for i := range context {
+			p.addImplicitContext(append(p.context, context[i:i+1]...))
+		}
+
+		/// Set the value.
+		val, typ := p.value(p.next(), false)
+		p.set(p.currentKey, val, typ)
+		p.ordered = append(p.ordered, p.context.add(p.currentKey))
+		hash[p.currentKey] = val
+
+		/// Restore context.
+		p.context = prevContext
+	}
+	p.context = outerContext
+	p.currentKey = outerKey
+	return hash, tomlHash
 }
 
 // numHasLeadingZero checks if this number has leading zeroes, allowing for '0',
@@ -417,7 +446,7 @@ func numPeriodsOK(s string) bool {
 //
 // Establishing the context also makes sure that the key isn't a duplicate, and
 // will create implicit hashes automatically.
-func (p *parser) establishContext(key Key, array bool) {
+func (p *parser) addContext(key Key, array bool) {
 	var ok bool
 
 	// Always start at the top level and drill down for our context.
@@ -456,7 +485,7 @@ func (p *parser) establishContext(key Key, array bool) {
 		// list of tables for it.
 		k := key[len(key)-1]
 		if _, ok := hashContext[k]; !ok {
-			hashContext[k] = make([]map[string]interface{}, 0, 5)
+			hashContext[k] = make([]map[string]interface{}, 0, 4)
 		}
 
 		// Add a new table. But make sure the key hasn't already been used
@@ -500,8 +529,7 @@ func (p *parser) setValue(key string, value interface{}) {
 		case map[string]interface{}:
 			hash = t
 		default:
-			p.bug("Expected hash to have type 'map[string]interface{}', but "+
-				"it has '%T' instead.", tmpHash)
+			p.panicf("Key '%s' has already been defined.", keyContext)
 		}
 	}
 	keyContext = append(keyContext, key)
@@ -544,21 +572,14 @@ func (p *parser) setType(key string, typ tomlType) {
 	p.types[keyContext.String()] = typ
 }
 
-// addImplicit sets the given Key as having been created implicitly.
-func (p *parser) addImplicit(key Key) {
-	p.implicits[key.String()] = true
-}
-
-// removeImplicit stops tagging the given key as having been implicitly
-// created.
-func (p *parser) removeImplicit(key Key) {
-	p.implicits[key.String()] = false
-}
-
-// isImplicit returns true if the key group pointed to by the key was created
-// implicitly.
-func (p *parser) isImplicit(key Key) bool {
-	return p.implicits[key.String()]
+// Implicit keys need to be created when tables are implied in "a.b.c.d = 1" and
+// "[a.b.c]" (the "a", "b", and "c" hashes are never created explicitly).
+func (p *parser) addImplicit(key Key)     { p.implicits[key.String()] = true }
+func (p *parser) removeImplicit(key Key)  { p.implicits[key.String()] = false }
+func (p *parser) isImplicit(key Key) bool { return p.implicits[key.String()] }
+func (p *parser) addImplicitContext(key Key) {
+	p.addImplicit(key)
+	p.addContext(key, false)
 }
 
 // current returns the full key name of the current context.
@@ -694,9 +715,4 @@ func (p *parser) asciiEscapeToUnicode(bs []byte) rune {
 		p.panicf("Escaped character '\\u%s' is not valid UTF-8.", s)
 	}
 	return rune(hex)
-}
-
-func isStringType(ty itemType) bool {
-	return ty == itemString || ty == itemMultilineString ||
-		ty == itemRawString || ty == itemRawMultilineString
 }

--- a/toml_test.go
+++ b/toml_test.go
@@ -51,7 +51,6 @@ func TestToml(t *testing.T) {
 			Encoder: enc,
 			Parser:  parser{},
 			SkipTests: []string{
-				"valid/key-dotted",
 				"valid/datetime-local-date",
 				"valid/datetime-local-time",
 				"valid/datetime-local",


### PR DESCRIPTION
Added in TOML 0.5; for example:

	a.b = 1

	[e.f]
	g.h = 3

Need to look at inline tables; that doesn't work yet:

	a = {b.c.d = 1}

Fixes #228
Fixes #242