### PR TITLE
Run toml-test as part of "go test"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,5 @@ jobs:
     - name: 'Checkout code'
       uses: 'actions/checkout@v2'
 
-    - name: 'Install'
-      run: |
-        go install ./...
-        curl -Ls 'https://github.com/BurntSushi/toml-test/releases/download/1.0.0-beta1/toml-test-v1.0.0-beta1-linux-amd64.gz' |
-            gzip -d - > toml-test
-        chmod a+x ./toml-test
-
     - name: 'Test'
-      run: 'make TOML_TEST=./toml-test'
+      run: 'make'

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,5 @@
-# toml: TOML array element cannot contain a table
-# Dotted keys are not supported yet.
-SKIP_ENCODE?=valid/inline-table-nest,valid/key-dotted
-
-# Dotted keys are not supported yet.
-SKIP_DECODE=valid/key-dotted
-
-# No easy way to see if this was a datetime or local datetime; we should extend
-# meta with new types for this, which seems like a good idea in any case.
-SKIP_DECODE+=,valid/datetime-local-date,valid/datetime-local-time,valid/datetime-local
-SKIP_ENCODE+=,valid/datetime-local-date,valid/datetime-local-time,valid/datetime-local
-
-# Location of toml-test
-TOML_TEST?=toml-test
-
 all:
 	@e=0  # So it won't stop on the first command that fails.
 	@go install ./...
 	@go test ./... || e=1
-	@${TOML_TEST} -skip="${SKIP_DECODE}" toml-test-decoder || e=1
-	@${TOML_TEST} -encoder -skip="${SKIP_ENCODE}" toml-test-encoder || e=1
 	@exit $e

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/BurntSushi/toml
 
 go 1.13
+
+require github.com/BurntSushi/toml-test v0.1.1-0.20210619051135-67b199419f32

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/BurntSushi/toml v0.3.2-0.20210614224209-34d990aa228d/go.mod h1:2QZjSXA5e+XyFeCAxxtL8Z4StYUsTquL8ODGPR3C3MA=
+github.com/BurntSushi/toml-test v0.1.1-0.20210619051135-67b199419f32 h1:h3GzZj1jBAKc2+lDW5UeN7LBSJLetljIUfjvWq+kpaA=
+github.com/BurntSushi/toml-test v0.1.1-0.20210619051135-67b199419f32/go.mod h1:P/PrhmZ37t5llHfDuiouWXtFgqOoQ12SAh9j6EjrBR4=
+zgo.at/zli v0.0.0-20210619044753-e7020a328e59/go.mod h1:HLAc12TjNGT+VRXr76JnsNE3pbooQtwKWhX+RlDjQ2Y=

--- a/session.vim
+++ b/session.vim
@@ -1,1 +1,0 @@
-au BufWritePost *.go silent!make tags > /dev/null 2>&1

--- a/toml_test.go
+++ b/toml_test.go
@@ -1,0 +1,44 @@
+package toml_test
+
+import (
+	"testing"
+
+	tomltest "github.com/BurntSushi/toml-test"
+)
+
+func TestToml(t *testing.T) {
+	run := func(t *testing.T, enc bool) {
+		t.Helper()
+		r := tomltest.Runner{
+			Files:     tomltest.EmbeddedTests(),
+			Encoder:   enc,
+			ParserCmd: []string{"toml-test-decoder"},
+			SkipTests: []string{"valid/key-dotted",
+				"valid/datetime-local-date",
+				"valid/datetime-local-time",
+				"valid/datetime-local"},
+		}
+		if enc {
+			r.ParserCmd = []string{"toml-test-encoder"}
+			r.SkipTests = append(r.SkipTests, "valid/inline-table-nest")
+		}
+
+		tests, err := r.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, test := range tests.Tests {
+			if test.Failed() {
+				t.Run(test.Path, func(t *testing.T) {
+					t.Errorf("\nError:\n%s\n\nInput:\n%s\nOutput:\n%s\nWant:\n%s\n",
+						test.Failure, test.Input, test.Output, test.Want)
+				})
+			}
+		}
+		t.Logf("passed: %d; failed: %d; skipped: %d", tests.Passed, tests.Failed, tests.Skipped)
+	}
+
+	t.Run("decode", func(t *testing.T) { run(t, false) })
+	t.Run("encode", func(t *testing.T) { run(t, true) })
+}


### PR DESCRIPTION
Still need to remove the dependency on the toml-test-{encoder,decoder}
tools, so it works before running "go install ./..." and we get code
coverage, but not having to install "toml-test" is already an
improvement.