### PR TITLE
Add Decoder struct and DecodeFS()

### DIFF
--- a/decode_go116.go
+++ b/decode_go116.go
@@ -1,0 +1,18 @@
+// +build go1.16
+
+package toml
+
+import (
+	"io/fs"
+)
+
+// DecodeFS is just like Decode, except it will automatically read the contents
+// of the file at `fpath` from a fs.FS instance.
+func DecodeFS(fsys fs.FS, fpath string, v interface{}) (MetaData, error) {
+	fp, err := fsys.Open(fpath)
+	if err != nil {
+		return MetaData{}, err
+	}
+	defer fp.Close()
+	return NewDecoder(fp).Decode(v)
+}

--- a/decode_go116_test.go
+++ b/decode_go116_test.go
@@ -1,0 +1,28 @@
+// +build go1.16
+
+package toml
+
+import (
+	"fmt"
+	"testing"
+	"testing/fstest"
+)
+
+func TestDecodeFS(t *testing.T) {
+	fsys := fstest.MapFS{
+		"test.toml": &fstest.MapFile{
+			Data: []byte("a = 42"),
+		},
+	}
+
+	var i struct{ A int }
+	meta, err := DecodeFS(fsys, "test.toml", &i)
+	if err != nil {
+		t.Fatal(err)
+	}
+	have := fmt.Sprintf("%v %v %v", i, meta.Keys(), meta.Type("a"))
+	want := "{42} [a] Integer"
+	if have != want {
+		t.Errorf("\nhave: %s\nwant: %s", have, want)
+	}
+}

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,6 +1,9 @@
 package toml
 
-import "encoding"
+import (
+	"encoding"
+	"io"
+)
 
 // DEPRECATED!
 //
@@ -20,4 +23,11 @@ type TextUnmarshaler encoding.TextUnmarshaler
 func PrimitiveDecode(primValue Primitive, v interface{}) error {
 	md := MetaData{decoded: make(map[string]bool)}
 	return md.unify(primValue.undecoded, rvalue(v))
+}
+
+// DEPRECATED!
+//
+// Use NewDecoder(reader).Decode(&v) instead.
+func DecodeReader(r io.Reader, v interface{}) (MetaData, error) {
+	return NewDecoder(r).Decode(v)
 }


### PR DESCRIPTION
Refactor things a wee bit to add a decoder struct. This doesn't really
*do* anything right now, but will be needed to add options, such as
"strict mode" in #197 or "extended errors" in #299.

Also add DecodeFS() as a companion to DecodeFile() to read from a fs.FS,
and since using a reader is the default with NewDecoder() (and was
already easy to do before with strings.NewReader()) I marked
DecodeReader() as deprecated.