### PR TITLE
Deal with invalid '\ ' escapes

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -789,9 +789,9 @@ func lexStringEscape(lx *lexer) stateFn {
 		fallthrough
 	case '"':
 		fallthrough
-	// Inside """ .. """ strings you can use \ to escape newlines, and any
-	// amount of whitespace can be between the \ and \n.
 	case ' ', '\t':
+		// Inside """ .. """ strings you can use \ to escape newlines, and any
+		// amount of whitespace can be between the \ and \n.
 		fallthrough
 	case '\\':
 		return lx.pop()

--- a/parse.go
+++ b/parse.go
@@ -664,6 +664,9 @@ func (p *parser) replaceEscapes(str string) string {
 		default:
 			p.bug("Expected valid escape code after \\, but got %q.", s[r])
 			return ""
+		case ' ', '\t':
+			p.panicf("invalid escape: '\\%c'", s[r])
+			return ""
 		case 'b':
 			replaced = append(replaced, rune(0x0008))
 			r += 1

--- a/toml_test.go
+++ b/toml_test.go
@@ -23,8 +23,9 @@ import (
 //
 // Filepaths are glob'd
 var errorTests = map[string][]string{
-	"encoding-bad-utf8*": {"invalid UTF-8 byte"},
-	"encoding-utf16*":    {"files cannot contain NULL bytes; probably using UTF-16"},
+	"encoding-bad-utf8*":            {"invalid UTF-8 byte"},
+	"encoding-utf16*":               {"files cannot contain NULL bytes; probably using UTF-16"},
+	"string-multiline-escape-space": {`invalid escape: '\ '`},
 }
 
 // Test metadata; all keys listed as "keyname: type".
@@ -58,7 +59,6 @@ func TestToml(t *testing.T) {
 				"valid/inline-table-nest",
 
 				"invalid/string-literal-multiline-quotes",
-				"invalid/string-multiline-escape-space",
 			},
 		}
 


### PR DESCRIPTION
These always got detected as newline escapes, even when they're invalid:

	"""
	asdas \    more text
	"""

Can't really find a good way to fix this in the lexer; so check for this
special case in the parser instead.