### PR TITLE
Allow mixed values in arrays

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -315,10 +315,8 @@ func (md *MetaData) unifyArray(data interface{}, rv reflect.Value) error {
 		}
 		return badtype("slice", data)
 	}
-	sliceLen := datav.Len()
-	if sliceLen != rv.Len() {
-		return e("expected array length %d; got TOML array of length %d",
-			rv.Len(), sliceLen)
+	if l := datav.Len(); l != rv.Len() {
+		return e("expected array length %d; got TOML array of length %d", rv.Len(), l)
 	}
 	return md.unifySliceArray(datav, rv)
 }
@@ -340,11 +338,10 @@ func (md *MetaData) unifySlice(data interface{}, rv reflect.Value) error {
 }
 
 func (md *MetaData) unifySliceArray(data, rv reflect.Value) error {
-	sliceLen := data.Len()
-	for i := 0; i < sliceLen; i++ {
-		v := data.Index(i).Interface()
-		sliceval := indirect(rv.Index(i))
-		if err := md.unify(v, sliceval); err != nil {
+	l := data.Len()
+	for i := 0; i < l; i++ {
+		err := md.unify(data.Index(i).Interface(), indirect(rv.Index(i)))
+		if err != nil {
 			return err
 		}
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -396,27 +396,32 @@ Fun = "why would you do this?"
 	}
 }
 
-func encodeExpected(
-	t *testing.T, label string, val interface{}, wantStr string, wantErr error,
-) {
+func encodeExpected(t *testing.T, label string, val interface{}, want string, wantErr error) {
 	t.Helper()
-	var buf bytes.Buffer
-	enc := NewEncoder(&buf)
-	err := enc.Encode(val)
-	if err != wantErr {
-		if wantErr != nil {
-			if wantErr == errAnything && err != nil {
-				return
+
+	t.Run(label, func(t *testing.T) {
+		var buf bytes.Buffer
+		err := NewEncoder(&buf).Encode(val)
+		if err != wantErr {
+			if wantErr != nil {
+				if wantErr == errAnything && err != nil {
+					return
+				}
+				t.Errorf("want Encode error %v, got %v", wantErr, err)
+			} else {
+				t.Errorf("Encode failed: %s", err)
 			}
-			t.Errorf("%s: want Encode error %v, got %v", label, wantErr, err)
-		} else {
-			t.Errorf("%s: Encode failed: %s", label, err)
 		}
-	}
-	if err != nil {
-		return
-	}
-	if got := buf.String(); wantStr != got {
-		t.Errorf("%s\nhave: %s\nwant: %s\n", label, got, wantStr)
-	}
+		if err != nil {
+			return
+		}
+
+		have := strings.TrimSpace(buf.String())
+		want = strings.TrimSpace(want)
+		if want != have {
+			t.Errorf("\nhave: %s\nwant: %s\n", have, want)
+			// v, _ := json.MarshalIndent(val, "", "  ")
+			// t.Log(string(v))
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/BurntSushi/toml
 
 go 1.13
 
-require github.com/BurntSushi/toml-test v0.1.1-0.20210624055653-1f6389604dc6
+require github.com/BurntSushi/toml-test v0.1.1-0.20210704062846-269931e74e3f

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.2-0.20210614224209-34d990aa228d/go.mod h1:2QZjSXA5e+XyFeCAxxtL8Z4StYUsTquL8ODGPR3C3MA=
 github.com/BurntSushi/toml v0.3.2-0.20210621044154-20a94d639b8e/go.mod h1:t4zg8TkHfP16Vb3x4WKIw7zVYMit5QFtPEO8lOWxzTg=
+github.com/BurntSushi/toml v0.3.2-0.20210624061728-01bfc69d1057/go.mod h1:NMj2lD5LfMqcE0w8tnqOsH6944oaqpI1974lrIwerfE=
 github.com/BurntSushi/toml-test v0.1.1-0.20210620192437-de01089bbf76/go.mod h1:P/PrhmZ37t5llHfDuiouWXtFgqOoQ12SAh9j6EjrBR4=
-github.com/BurntSushi/toml-test v0.1.1-0.20210624055653-1f6389604dc6 h1:hRkQ1B9Jtdssyzo0Cr3EgS2WMwPscGNrCDNCeYshAQA=
 github.com/BurntSushi/toml-test v0.1.1-0.20210624055653-1f6389604dc6/go.mod h1:UAIt+Eo8itMZAAgImXkPGDMYsT1SsJkVdB5TuONl86A=
+github.com/BurntSushi/toml-test v0.1.1-0.20210704062846-269931e74e3f h1:2bJvwBZX/Ajv19zGY3hvuHDInegqjxsz9ht9Smlr7Rk=
+github.com/BurntSushi/toml-test v0.1.1-0.20210704062846-269931e74e3f/go.mod h1:fnFWrIwqgHsEjVsW3RYCJmDo86oq9eiJ9u6bnqhtm2g=
 zgo.at/zli v0.0.0-20210619044753-e7020a328e59/go.mod h1:HLAc12TjNGT+VRXr76JnsNE3pbooQtwKWhX+RlDjQ2Y=

--- a/move_test.go
+++ b/move_test.go
@@ -198,12 +198,12 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 			wantOutput: "Empty = []\n",
 		},
 		"(error) slice with element type mismatch (string and integer)": {
-			input:     struct{ Mixed []interface{} }{[]interface{}{1, "a"}},
-			wantError: errArrayMixedElementTypes,
+			input:      struct{ Mixed []interface{} }{[]interface{}{1, "a"}},
+			wantOutput: "Mixed = [1, \"a\"]\n",
 		},
 		"(error) slice with element type mismatch (integer and float)": {
-			input:     struct{ Mixed []interface{} }{[]interface{}{1, 2.5}},
-			wantError: errArrayMixedElementTypes,
+			input:      struct{ Mixed []interface{} }{[]interface{}{1, 2.5}},
+			wantOutput: "Mixed = [1, 2.5]\n",
 		},
 		"slice with elems of differing Go types, same TOML types": {
 			input: struct {
@@ -223,7 +223,7 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 			input: struct{ Mixed []interface{} }{
 				[]interface{}{1, []interface{}{2}},
 			},
-			wantError: errArrayMixedElementTypes,
+			wantOutput: "Mixed = [1, [2]]\n",
 		},
 		"(error) slice with 1 nil element": {
 			input:     struct{ NilElement1 []interface{} }{[]interface{}{nil}},
@@ -379,17 +379,41 @@ ArrayOfMixedSlices = [[1, 2], ["a", "b"]]
 			input:     []struct{ Int int }{{1}, {2}, {3}},
 			wantError: errNoKey,
 		},
-		"(error) slice of slice": {
+		"(error) map no string key": {
+			input:     map[int]string{1: ""},
+			wantError: errNonString,
+		},
+
+		"tbl-in-arr-struct": {
+			input: struct {
+				Arr [][]struct{ A, B, C int }
+			}{[][]struct{ A, B, C int }{{{1, 2, 3}, {4, 5, 6}}}},
+			wantOutput: "Arr = [[{A = 1, B = 2, C = 3}, {A = 4, B = 5, C = 6}]]",
+		},
+
+		"tbl-in-arr-map": {
+			input: map[string]interface{}{
+				"arr": []interface{}{[]interface{}{
+					map[string]interface{}{
+						"a": []interface{}{"hello", "world"},
+						"b": []interface{}{1.12, 4.1},
+						"c": 1,
+						"d": map[string]interface{}{"e": "E"},
+						"f": struct{ A, B int }{1, 2},
+						"g": []struct{ A, B int }{{3, 4}, {5, 6}},
+					},
+				}},
+			},
+			wantOutput: `arr = [[{a = ["hello", "world"], b = [1.12, 4.1], c = 1, d = {e = "E"}, f = {A = 1, B = 2}, g = [{A = 3, B = 4}, {A = 5, B = 6}]}]]`,
+		},
+
+		"slice of slice": {
 			input: struct {
 				Slices [][]struct{ Int int }
 			}{
 				[][]struct{ Int int }{{{1}}, {{2}}, {{3}}},
 			},
-			wantError: errArrayNoTable,
-		},
-		"(error) map no string key": {
-			input:     map[int]string{1: ""},
-			wantError: errNonString,
+			wantOutput: "Slices = [[{Int = 1}], [{Int = 2}], [{Int = 3}]]",
 		},
 	}
 	for label, test := range tests {

--- a/toml_test.go
+++ b/toml_test.go
@@ -52,8 +52,6 @@ func TestToml(t *testing.T) {
 				"valid/datetime-local-date",
 				"valid/datetime-local-time",
 				"valid/datetime-local",
-				"valid/array-mix-string-table",
-				"valid/inline-table-nest",
 			},
 		}
 

--- a/type_check.go
+++ b/type_check.go
@@ -68,24 +68,3 @@ func (p *parser) typeOfPrimitive(lexItem item) tomlType {
 	p.bug("Cannot infer primitive type of lex item '%s'.", lexItem)
 	panic("unreachable")
 }
-
-// typeOfArray returns a tomlType for an array given a list of types of its
-// values.
-//
-// In the current spec, if an array is homogeneous, then its type is always
-// "Array". If the array is not homogeneous, an error is generated.
-func (p *parser) typeOfArray(types []tomlType) tomlType {
-	// Empty arrays are cool.
-	if len(types) == 0 {
-		return tomlArray
-	}
-
-	theType := types[0]
-	for _, t := range types[1:] {
-		if !typeEqual(theType, t) {
-			p.panicf("Array contains values of type '%s' and '%s', but "+
-				"arrays must be homogeneous.", theType, t)
-		}
-	}
-	return tomlArray
-}


### PR DESCRIPTION
Decoding of mixed arrays work:

	[1, 1.0]  # Int and float
	['a', 1]
	['a', {tbl=42}, [[{a=1}]]]

This also adds encoding of inline tables, as otherwise we can't encode
arrays with tables in them.

Fixes #305