### PR TITLE
Allow lossless integer to float conversions

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -39,9 +39,8 @@ type Primitive struct {
 	context   Key
 }
 
-// The significand precision for float32 and float64 is 24 and
-// 53 bits respectfully. 2^prec-1 gives us the range an integer
-// can be stored within a float without loss of data.
+// The significand precision for float32 and float64 is 24 and 53 bits; this is
+// the range a natural number can be stored in a float without loss of data.
 const (
 	maxSafeFloat32Int = 16777215         // 2^24-1
 	maxSafeFloat64Int = 9007199254740991 // 2^53-1
@@ -225,9 +224,7 @@ func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 			return e("unsupported type %s", rv.Type())
 		}
 		return md.unifyAnything(data, rv)
-	case reflect.Float32:
-		fallthrough
-	case reflect.Float64:
+	case reflect.Float32, reflect.Float64:
 		return md.unifyFloat64(data, rv)
 	}
 	return e("unsupported type %s", rv.Kind())

--- a/decode_test.go
+++ b/decode_test.go
@@ -268,49 +268,46 @@ func TestDecodeIntOverflow(t *testing.T) {
 }
 
 func TestDecodeFloatOverflow(t *testing.T) {
-	type table struct {
-		F32 float32
-		F64 float64
-	}
-
 	tests := []struct {
 		value    string
 		overflow bool
 	}{
 		{fmt.Sprintf(`F32 = %f`, math.MaxFloat64), true},
 		{fmt.Sprintf(`F32 = %f`, -math.MaxFloat64), true},
-		{fmt.Sprintf(`F32 = %f`, math.MaxFloat32), false},
-		{fmt.Sprintf(`F32 = %f`, -math.MaxFloat32), false},
 		{fmt.Sprintf(`F32 = %f`, math.MaxFloat32*1.1), true},
 		{fmt.Sprintf(`F32 = %f`, -math.MaxFloat32*1.1), true},
-
-		{fmt.Sprintf(`F32 = %d`, maxSafeFloat32Int), false},
-		{fmt.Sprintf(`F32 = %d`, -maxSafeFloat32Int), false},
 		{fmt.Sprintf(`F32 = %d`, maxSafeFloat32Int+1), true},
 		{fmt.Sprintf(`F32 = %d`, -maxSafeFloat32Int-1), true},
+		{fmt.Sprintf(`F64 = %d`, maxSafeFloat64Int+1), true},
+		{fmt.Sprintf(`F64 = %d`, -maxSafeFloat64Int-1), true},
 
+		{fmt.Sprintf(`F32 = %f`, math.MaxFloat32), false},
+		{fmt.Sprintf(`F32 = %f`, -math.MaxFloat32), false},
+		{fmt.Sprintf(`F32 = %d`, maxSafeFloat32Int), false},
+		{fmt.Sprintf(`F32 = %d`, -maxSafeFloat32Int), false},
 		{fmt.Sprintf(`F64 = %f`, math.MaxFloat64), false},
 		{fmt.Sprintf(`F64 = %f`, -math.MaxFloat64), false},
 		{fmt.Sprintf(`F64 = %f`, math.MaxFloat32), false},
 		{fmt.Sprintf(`F64 = %f`, -math.MaxFloat32), false},
-
 		{fmt.Sprintf(`F64 = %d`, maxSafeFloat64Int), false},
 		{fmt.Sprintf(`F64 = %d`, -maxSafeFloat64Int), false},
-		{fmt.Sprintf(`F64 = %d`, maxSafeFloat64Int+1), true},
-		{fmt.Sprintf(`F64 = %d`, -maxSafeFloat64Int-1), true},
 	}
 
-	for _, tc := range tests {
-		var tab table
-		_, err := Decode(tc.value, &tab)
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			var tab struct {
+				F32 float32
+				F64 float64
+			}
+			_, err := Decode(tt.value, &tab)
 
-		if tc.overflow && err == nil {
-			t.Fatalf("expected error for %q", tc.value)
-		}
-
-		if !tc.overflow && err != nil {
-			t.Fatalf("unexpected error for %q: %v", tc.value, err)
-		}
+			if tt.overflow && err == nil {
+				t.Fatal("expected error, but err is nil")
+			}
+			if (tt.overflow && !errorContains(err, "out of range")) || (!tt.overflow && err != nil) {
+				t.Fatalf("unexpected error:\n%v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
According to the specification, 64-bit signed integers should be accepted providing they can be represented losslessly.

At the moment, integers to be converted to a float immediately return an error. This change permits integers and only returns an error if they would overflow the float type they're being converted to as they have no problem being represented losslessly.

In addition, this change returns an error if a float is provided but cannot fit within the float type specified by the struct.

This relates to issue https://github.com/BurntSushi/toml/issues/60, which I believe was incorrectly closed:

> BurntSushi:
> This appears to be working as intended. In TOML, floats are indicated by the presence of a decimal point and at least one trailing 0.

Whilst this statement is true, that concerns the input of a float. I believe an argument can be made that the input here concerns an integer, that just so happens to be unmarsharled into a float. It *can* be represented losslessly. Only integers that cannot be should return an error.