### PR TITLE
Add Marshaler interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-## TOML parser and encoder for Go with reflection
-
 TOML stands for Tom's Obvious, Minimal Language. This Go package provides a
 reflection interface similar to Go's standard library `json` and `xml`
-packages. This package also supports the `encoding.TextUnmarshaler` and
-`encoding.TextMarshaler` interfaces so that you can define custom data
-representations. (There is an example of this below.)
+packages.
 
 Compatible with TOML version [v1.0.0](https://toml.io/en/v1.0.0).
 
@@ -16,26 +12,25 @@ v0.4.0`).
 
 This library requires Go 1.13 or newer; install it with:
 
-    $ go get github.com/BurntSushi/toml
+    % go get github.com/BurntSushi/toml@latest
 
 It also comes with a TOML validator CLI tool:
 
-    $ go get github.com/BurntSushi/toml/cmd/tomlv
-    $ tomlv some-toml-file.toml
+    % go install github.com/BurntSushi/toml/cmd/tomlv@latest
+    % tomlv some-toml-file.toml
 
 ### Testing
+This package passes all tests in [toml-test] for both the decoder and the
+encoder.
 
-This package passes all tests in
-[toml-test](https://github.com/BurntSushi/toml-test) for both the decoder
-and the encoder.
+[toml-test]: https://github.com/BurntSushi/toml-test
 
 ### Examples
+This package works similar to how the Go standard library handles XML and JSON.
+Namely, data is loaded into Go values via reflection.
 
-This package works similarly to how the Go standard library handles XML and
-JSON. Namely, data is loaded into Go values via reflection.
-
-For the simplest example, consider some TOML file as just a list of keys
-and values:
+For the simplest example, consider some TOML file as just a list of keys and
+values:
 
 ```toml
 Age = 25
@@ -61,9 +56,8 @@ And then decoded with:
 
 ```go
 var conf Config
-if _, err := toml.Decode(tomlData, &conf); err != nil {
-  // handle error
-}
+err := toml.Decode(tomlData, &conf)
+// handle error
 ```
 
 You can also use struct tags if your struct field name doesn't map to a TOML
@@ -75,15 +69,14 @@ some_key_NAME = "wat"
 
 ```go
 type TOML struct {
-  ObscureKey string `toml:"some_key_NAME"`
+    ObscureKey string `toml:"some_key_NAME"`
 }
 ```
 
 Beware that like other most other decoders **only exported fields** are
 considered when encoding and decoding; private fields are silently ignored.
 
-### Using the `encoding.TextUnmarshaler` interface
-
+### Using the `Marshaler` and `encoding.TextUnmarshaler` interfaces
 Here's an example that automatically parses duration strings into
 `time.Duration` values:
 
@@ -136,7 +129,6 @@ To target TOML specifically you can implement `UnmarshalTOML` TOML interface in
 a similar way.
 
 ### More complex usage
-
 Here's an example of how to load the example from the official spec page:
 
 ```toml
@@ -217,4 +209,3 @@ Note that a case insensitive match will be tried if an exact match can't be
 found.
 
 A working example of the above can be found in `_examples/example.{go,toml}`.
-

--- a/decode.go
+++ b/decode.go
@@ -431,6 +431,12 @@ func (md *MetaData) unifyAnything(data interface{}, rv reflect.Value) error {
 func (md *MetaData) unifyText(data interface{}, v encoding.TextUnmarshaler) error {
 	var s string
 	switch sdata := data.(type) {
+	case Marshaler:
+		text, err := sdata.MarshalTOML()
+		if err != nil {
+			return err
+		}
+		s = string(text)
 	case TextMarshaler:
 		text, err := sdata.MarshalText()
 		if err != nil {


### PR DESCRIPTION
Ass Marshaler interface with the MarhsalTOML method to specifically
target TOML. This is similar to e.g. json.Marshaler, and takes
precedence over encoding.TextMarshaler.

Fixes #76