### PR TITLE
Support encoding comments and specifying the encoding format

### DIFF
--- a/cmd/toml-test-decoder/main.go
+++ b/cmd/toml-test-decoder/main.go
@@ -31,13 +31,14 @@ func main() {
 	}
 
 	var decoded interface{}
-	if _, err := toml.DecodeReader(os.Stdin, &decoded); err != nil {
+	meta, err := toml.DecodeReader(os.Stdin, &decoded)
+	if err != nil {
 		log.Fatalf("Error decoding TOML: %s", err)
 	}
 
 	j := json.NewEncoder(os.Stdout)
 	j.SetIndent("", "  ")
-	if err := j.Encode(tag.Add("", decoded)); err != nil {
+	if err := j.Encode(tag.Add(meta, "", decoded)); err != nil {
 		log.Fatalf("Error encoding JSON: %s", err)
 	}
 }

--- a/decode.go
+++ b/decode.go
@@ -128,11 +128,12 @@ func (dec *Decoder) Decode(v interface{}) (MetaData, error) {
 		return MetaData{}, err
 	}
 	md := MetaData{
-		mapping: p.mapping,
-		types:   p.types,
-		keys:    p.ordered,
-		decoded: make(map[string]bool, len(p.ordered)),
-		context: nil,
+		mapping:  p.mapping,
+		types:    p.types,
+		keys:     p.ordered,
+		comments: p.comments,
+		decoded:  make(map[string]bool, len(p.ordered)),
+		context:  nil,
 	}
 	return md, md.unify(p.mapping, indirect(rv))
 }
@@ -462,6 +463,7 @@ func (md *MetaData) unifyText(data interface{}, v encoding.TextUnmarshaler) erro
 	var s string
 	switch sdata := data.(type) {
 	case Marshaler:
+		fmt.Println("unifyText (Marshaler)", data, "in to", v)
 		text, err := sdata.MarshalTOML()
 		if err != nil {
 			return err
@@ -473,6 +475,7 @@ func (md *MetaData) unifyText(data interface{}, v encoding.TextUnmarshaler) erro
 			return err
 		}
 		s = string(text)
+		// fmt.Println("unifyText (TextMarshaler)", data, "in to", v, "=", s)
 	case fmt.Stringer:
 		s = sdata.String()
 	case string:

--- a/encode.go
+++ b/encode.go
@@ -2,6 +2,7 @@ package toml
 
 import (
 	"bufio"
+	"bytes"
 	"encoding"
 	"errors"
 	"fmt"
@@ -98,8 +99,16 @@ type Encoder struct {
 	// String to use for a single indentation level; default is two spaces.
 	Indent string
 
+	// TODO(v2): Ident should be a function so we can do:
+	//
+	//   NewEncoder(os.Stdout).SetIndent("prefix", "indent").MetaData(meta).Encode()
+	//
+	// Prefix is also useful to have.
+
 	w          *bufio.Writer
 	hasWritten bool // written any output to w yet?
+	wroteNL    int  // How many newlines do we have in a row?
+	meta       *MetaData
 }
 
 // NewEncoder create a new Encoder.
@@ -108,6 +117,17 @@ func NewEncoder(w io.Writer) *Encoder {
 		w:      bufio.NewWriter(w),
 		Indent: "  ",
 	}
+}
+
+// MetaData sets the metadata for this encoder.
+//
+// This can be used to control the formatting; see the documentation of MetaData
+// for more details.
+//
+// XXX: Rename to SetMeta()
+func (enc *Encoder) MetaData(m MetaData) *Encoder {
+	enc.meta = &m
+	return enc
 }
 
 // Encode writes a TOML representation of the Go value to the Encoder's writer.
@@ -136,7 +156,39 @@ func (enc *Encoder) safeEncode(key Key, rv reflect.Value) (err error) {
 	return nil
 }
 
+// Newline rules:
+
+// nocomment = "value"
+// no_bl = 1
+//
+// # With comment: has blank line before the comment, and one after the key.
+// with_c = 2
+//
+// asd = 1
+// qwe = 2  # After comment: no extra newline
+// zxc = 3
+//
+// [tbl]  # Always has newline before it.key
+//
+// # With comment
+// [tbl2]
+//   key1 = 123
+//
+//
 func (enc *Encoder) encode(key Key, rv reflect.Value) {
+	extraNL := false
+	if enc.meta != nil && enc.meta.comments != nil {
+		comments := enc.meta.comments[key.String()]
+		for _, c := range comments {
+			if c.where == commentDoc {
+				extraNL = true
+				enc.w.WriteString("# ")
+				enc.w.WriteString(strings.ReplaceAll(c.text, "\n", "\n# "))
+				enc.newline(1)
+			}
+		}
+	}
+
 	// Special case: time needs to be in ISO8601 format.
 	//
 	// Special case: if we can marshal the type to text, then we used that. This
@@ -145,112 +197,182 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) {
 	switch t := rv.Interface().(type) {
 	case time.Time, encoding.TextMarshaler, Marshaler:
 		enc.writeKeyValue(key, rv, false)
-		return
 	// TODO: #76 would make this superfluous after implemented.
+	// TODO: remove in v2
 	case Primitive:
 		enc.encode(key, reflect.ValueOf(t.undecoded))
-		return
+	default:
+
+		k := rv.Kind()
+		switch k {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+			reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
+			reflect.Uint64,
+			reflect.Float32, reflect.Float64, reflect.String, reflect.Bool:
+			enc.writeKeyValue(key, rv, false)
+		case reflect.Array, reflect.Slice:
+			if typeEqual(ArrayTable{}, tomlTypeOfGo(rv)) {
+				enc.eArrayOfTables(key, rv)
+			} else {
+				enc.writeKeyValue(key, rv, false)
+			}
+		case reflect.Interface:
+			if rv.IsNil() {
+				return
+			}
+			enc.encode(key, rv.Elem())
+		case reflect.Map:
+			if rv.IsNil() {
+				return
+			}
+			enc.eTable(key, rv)
+		case reflect.Ptr:
+			if rv.IsNil() {
+				return
+			}
+			enc.encode(key, rv.Elem())
+		case reflect.Struct:
+			enc.eTable(key, rv)
+		default:
+			encPanic(fmt.Errorf("unsupported type for key '%s': %s", key, k))
+		}
 	}
 
-	k := rv.Kind()
-	switch k {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
-		reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
-		reflect.Uint64,
-		reflect.Float32, reflect.Float64, reflect.String, reflect.Bool:
-		enc.writeKeyValue(key, rv, false)
-	case reflect.Array, reflect.Slice:
-		if typeEqual(tomlArrayHash, tomlTypeOfGo(rv)) {
-			enc.eArrayOfTables(key, rv)
-		} else {
-			enc.writeKeyValue(key, rv, false)
+	// Write comments after the key.
+	if enc.meta != nil && enc.meta.comments != nil {
+		comments := enc.meta.comments[key.String()]
+		for _, c := range comments {
+			if c.where == commentComment {
+				enc.w.WriteString("  # ")
+				enc.w.WriteString(strings.ReplaceAll(c.text, "\n", "\n# "))
+				enc.newline(1)
+			}
 		}
-	case reflect.Interface:
-		if rv.IsNil() {
-			return
-		}
-		enc.encode(key, rv.Elem())
-	case reflect.Map:
-		if rv.IsNil() {
-			return
-		}
-		enc.eTable(key, rv)
-	case reflect.Ptr:
-		if rv.IsNil() {
-			return
-		}
-		enc.encode(key, rv.Elem())
-	case reflect.Struct:
-		enc.eTable(key, rv)
-	default:
-		encPanic(fmt.Errorf("unsupported type for key '%s': %s", key, k))
+	}
+
+	enc.newline(1)
+	if extraNL {
+		enc.newline(1)
 	}
 }
 
+func (enc *Encoder) writeInt(typ tomlType, v uint64) {
+	var (
+		iTyp = asInt(typ)
+		base = int(iTyp.Base)
+	)
+	switch iTyp.Base {
+	case 0:
+		base = 10
+	case 2:
+		enc.wf("0b")
+	case 8:
+		enc.wf("0o")
+	case 16:
+		enc.wf("0x")
+	}
+
+	n := strconv.FormatUint(uint64(v), base)
+	if base != 10 && iTyp.Width > 0 && len(n) < int(iTyp.Width) {
+		enc.wf(strings.Repeat("0", int(iTyp.Width)-len(n)))
+	}
+	enc.wf(n)
+}
+
 // eElement encodes any value that can be an array element.
-func (enc *Encoder) eElement(rv reflect.Value) {
+func (enc *Encoder) eElement(rv reflect.Value, typ tomlType) {
+	//fmt.Printf("ENC %T -> %s -> %[1]v\n", rv.Interface(), typ)
+
 	switch v := rv.Interface().(type) {
 	case time.Time: // Using TextMarshaler adds extra quotes, which we don't want.
-		format := time.RFC3339Nano
-		switch v.Location() {
-		case internal.LocalDatetime:
+		format := ""
+		switch asDatetime(typ).Format {
+		case 0: // Undefined, check for special TZ.
+			format = time.RFC3339Nano
+			switch v.Location() {
+			case internal.LocalDatetime:
+				format = "2006-01-02T15:04:05.999999999"
+			case internal.LocalDate:
+				format = "2006-01-02"
+			case internal.LocalTime:
+				format = "15:04:05.999999999"
+			}
+
+		case DatetimeFormatFull:
+			format = time.RFC3339Nano
+		case DatetimeFormatLocal:
 			format = "2006-01-02T15:04:05.999999999"
-		case internal.LocalDate:
+		case DatetimeFormatDate:
 			format = "2006-01-02"
-		case internal.LocalTime:
+		case DatetimeFormatTime:
 			format = "15:04:05.999999999"
-		}
-		switch v.Location() {
 		default:
-			enc.wf(v.Format(format))
-		case internal.LocalDatetime, internal.LocalDate, internal.LocalTime:
-			enc.wf(v.In(time.UTC).Format(format))
+			encPanic(fmt.Errorf("Invalid datetime format: %v", asDatetime(typ).Format))
 		}
+
+		//fmt.Printf("ENC %T -> %s -> %[1]v\n", rv.Interface(), typ)
+		//fmt.Println("XXX", asDatetime(typ).Format)
+		if format != time.RFC3339Nano {
+			//v = v.In(time.UTC)
+		}
+
+		//switch v.Location() {
+		//default:
+		enc.wf(v.Format(format))
+		//case internal.LocalDatetime, internal.LocalDate, internal.LocalTime:
+		//	enc.wf(v.In(time.UTC).Format(format))
+		//}
 		return
 	case Marshaler:
 		s, err := v.MarshalTOML()
 		if err != nil {
 			encPanic(err)
 		}
-		enc.writeQuoted(string(s))
+		enc.writeQuoted(string(s), asString(typ))
 		return
 	case encoding.TextMarshaler:
 		s, err := v.MarshalText()
 		if err != nil {
 			encPanic(err)
 		}
-		enc.writeQuoted(string(s))
+		enc.writeQuoted(string(s), asString(typ))
 		return
 	}
 
 	switch rv.Kind() {
-	case reflect.String:
-		enc.writeQuoted(rv.String())
 	case reflect.Bool:
 		enc.wf(strconv.FormatBool(rv.Bool()))
+	case reflect.String:
+		enc.writeQuoted(rv.String(), asString(typ))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		enc.wf(strconv.FormatInt(rv.Int(), 10))
+		v := rv.Int()
+		if v < 0 { // Make sure sign is before "0x".
+			enc.wf("-")
+			v = -v
+		}
+		enc.writeInt(typ, uint64(v))
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		enc.wf(strconv.FormatUint(rv.Uint(), 10))
-	case reflect.Float32:
+		enc.writeInt(typ, rv.Uint())
+
+	case reflect.Float32, reflect.Float64:
 		f := rv.Float()
 		if math.IsNaN(f) {
 			enc.wf("nan")
 		} else if math.IsInf(f, 0) {
 			enc.wf("%cinf", map[bool]byte{true: '-', false: '+'}[math.Signbit(f)])
 		} else {
-			enc.wf(floatAddDecimal(strconv.FormatFloat(f, 'f', -1, 32)))
+			n := 64
+			if rv.Kind() == reflect.Float32 {
+				n = 32
+			}
+			if asFloat(typ).Exponent {
+				enc.wf(strconv.FormatFloat(f, 'e', -1, n))
+			} else {
+				enc.wf(floatAddDecimal(strconv.FormatFloat(f, 'f', -1, n)))
+			}
 		}
-	case reflect.Float64:
-		f := rv.Float()
-		if math.IsNaN(f) {
-			enc.wf("nan")
-		} else if math.IsInf(f, 0) {
-			enc.wf("%cinf", map[bool]byte{true: '-', false: '+'}[math.Signbit(f)])
-		} else {
-			enc.wf(floatAddDecimal(strconv.FormatFloat(f, 'f', -1, 64)))
-		}
+
 	case reflect.Array, reflect.Slice:
 		enc.eArrayOrSliceElement(rv)
 	case reflect.Struct:
@@ -258,7 +380,7 @@ func (enc *Encoder) eElement(rv reflect.Value) {
 	case reflect.Map:
 		enc.eMap(nil, rv, true)
 	case reflect.Interface:
-		enc.eElement(rv.Elem())
+		enc.eElement(rv.Elem(), typ)
 	default:
 		encPanic(fmt.Errorf("unexpected primitive type: %T", rv.Interface()))
 	}
@@ -273,8 +395,21 @@ func floatAddDecimal(fstr string) string {
 	return fstr
 }
 
-func (enc *Encoder) writeQuoted(s string) {
-	enc.wf("\"%s\"", dblQuotedReplacer.Replace(s))
+func (enc *Encoder) writeQuoted(s string, typ String) {
+	if typ.Literal {
+		if typ.Multiline {
+			enc.wf("'''%s'''\n", s)
+		} else {
+			enc.wf(`'%s'`, s)
+		}
+	} else {
+		if typ.Multiline {
+			enc.wf(`"""%s"""`+"\n",
+				strings.ReplaceAll(dblQuotedReplacer.Replace(s), "\\n", "\n"))
+		} else {
+			enc.wf(`"%s"`, dblQuotedReplacer.Replace(s))
+		}
+	}
 }
 
 func (enc *Encoder) eArrayOrSliceElement(rv reflect.Value) {
@@ -282,7 +417,7 @@ func (enc *Encoder) eArrayOrSliceElement(rv reflect.Value) {
 	enc.wf("[")
 	for i := 0; i < length; i++ {
 		elem := rv.Index(i)
-		enc.eElement(elem)
+		enc.eElement(elem, nil) // XXX: add type
 		if i != length-1 {
 			enc.wf(", ")
 		}
@@ -299,22 +434,21 @@ func (enc *Encoder) eArrayOfTables(key Key, rv reflect.Value) {
 		if isNil(trv) {
 			continue
 		}
-		enc.newline()
+
+		enc.newline(2)
 		enc.wf("%s[[%s]]", enc.indentStr(key), key.maybeQuotedAll())
-		enc.newline()
+		enc.newline(1)
 		enc.eMapOrStruct(key, trv, false)
 	}
 }
 
 func (enc *Encoder) eTable(key Key, rv reflect.Value) {
-	if len(key) == 1 {
-		// Output an extra newline between top-level tables.
-		// (The newline isn't written if nothing else has been written though.)
-		enc.newline()
+	if len(key) == 1 { // Output an extra newline between top-level tables.
+		enc.newline(2)
 	}
 	if len(key) > 0 {
 		enc.wf("%s[%s]", enc.indentStr(key), key.maybeQuotedAll())
-		enc.newline()
+		enc.newline(1)
 	}
 	enc.eMapOrStruct(key, rv, false)
 }
@@ -501,46 +635,46 @@ func tomlTypeOfGo(rv reflect.Value) tomlType {
 	}
 	switch rv.Kind() {
 	case reflect.Bool:
-		return tomlBool
+		return Bool{}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
 		reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
 		reflect.Uint64:
-		return tomlInteger
+		return Int{}
 	case reflect.Float32, reflect.Float64:
-		return tomlFloat
+		return Float{}
 	case reflect.Array, reflect.Slice:
-		if typeEqual(tomlHash, tomlArrayType(rv)) {
-			return tomlArrayHash
+		if typeEqual(Table{}, tomlArrayType(rv)) {
+			return ArrayTable{}
 		}
-		return tomlArray
+		return Array{}
 	case reflect.Ptr, reflect.Interface:
 		return tomlTypeOfGo(rv.Elem())
 	case reflect.String:
-		return tomlString
+		return String{}
 	case reflect.Map:
-		return tomlHash
+		return Table{}
 	case reflect.Struct:
 		switch rv.Interface().(type) {
 		case time.Time:
-			return tomlDatetime
+			return Datetime{}
 		case encoding.TextMarshaler:
-			return tomlString
+			return String{}
 		default:
 			// Someone used a pointer receiver: we can make it work for pointer
 			// values.
 			if rv.CanAddr() {
 				_, ok := rv.Addr().Interface().(encoding.TextMarshaler)
 				if ok {
-					return tomlString
+					return String{}
 				}
 			}
-			return tomlHash
+			return Table{}
 		}
 	default:
 		_, ok := rv.Interface().(encoding.TextMarshaler)
 		if ok {
-			return tomlString
+			return String{}
 		}
 		encPanic(errors.New("unsupported type: " + rv.Kind().String()))
 		panic("") // Need *some* return value
@@ -620,9 +754,23 @@ func isEmpty(rv reflect.Value) bool {
 	return false
 }
 
-func (enc *Encoder) newline() {
-	if enc.hasWritten {
-		enc.wf("\n")
+// newline ensures there are n newlines here.
+func (enc *Encoder) newline(n int) {
+	// Don't write any newlines at the top of the file.
+	if !enc.hasWritten {
+		return
+	}
+
+	w := n - enc.wroteNL
+	if w <= 0 {
+		return
+	}
+
+	enc.wroteNL += w
+	//enc.wf(strings.Repeat("\n", w))
+	_, err := enc.w.Write(bytes.Repeat([]byte("\n"), w))
+	if err != nil {
+		encPanic(err)
 	}
 }
 
@@ -637,16 +785,22 @@ func (enc *Encoder) newline() {
 //     │      ┌───┐  ┌─────┐│
 //     v      v   v  v     vv
 //     key = {k = v, k2 = v2}
-//
 func (enc *Encoder) writeKeyValue(key Key, val reflect.Value, inline bool) {
 	if len(key) == 0 {
 		encPanic(errNoKey)
 	}
 	enc.wf("%s%s = ", enc.indentStr(key), key.maybeQuoted(len(key)-1))
-	enc.eElement(val)
-	if !inline {
-		enc.newline()
+
+	var typ tomlType
+	if enc.meta != nil {
+		if t, ok := enc.meta.types[key.String()]; ok {
+			typ = t
+		}
 	}
+	enc.eElement(val, typ)
+	// if !inline {
+	// 	enc.newline()
+	// }
 }
 
 func (enc *Encoder) wf(format string, v ...interface{}) {
@@ -654,6 +808,7 @@ func (enc *Encoder) wf(format string, v ...interface{}) {
 	if err != nil {
 		encPanic(err)
 	}
+	enc.wroteNL = 0
 	enc.hasWritten = true
 }
 

--- a/internal/tag/rm.go
+++ b/internal/tag/rm.go
@@ -78,6 +78,21 @@ func untag(typed map[string]interface{}) (interface{}, error) {
 			return nil, fmt.Errorf("untag: %w", err)
 		}
 		return f, nil
+
+	// XXX: this loses the "meta" information that's required.
+	// this is a bit annoying: the datetime is the only type that requires
+	// access to the metadata to be semantically correct. All the other values
+	// have different notations, but are semantically identical (0x10 == 16).
+	//
+	// Maybe add back the special timezones we used before, so the time.Time
+	// is "self-contained"?
+	//
+	// When decoding -> set both meta and type
+	//
+	// When encoding -> use meta if set, falling back to the TZ.
+	//
+	// time.Now() will encode as "full", unless meta is set.
+	// Decoding a time and setting meta to "full" will encode as such.
 	case "datetime":
 		return parseTime(v, "2006-01-02T15:04:05.999999999Z07:00", nil)
 	case "datetime-local":
@@ -86,6 +101,7 @@ func untag(typed map[string]interface{}) (interface{}, error) {
 		return parseTime(v, "2006-01-02", internal.LocalDate)
 	case "time-local":
 		return parseTime(v, "15:04:05.999999999", internal.LocalTime)
+
 	case "bool":
 		switch v {
 		case "true":

--- a/toml_test.go
+++ b/toml_test.go
@@ -182,7 +182,8 @@ func (p parser) Encode(input string) (output string, outputIsError bool, retErr 
 	}
 
 	buf := new(bytes.Buffer)
-	err = toml.NewEncoder(buf).Encode(rm)
+	enc := toml.NewEncoder(buf)
+	err = enc.Encode(rm)
 	if err != nil {
 		return err.Error(), true, retErr
 	}
@@ -203,11 +204,12 @@ func (p parser) Decode(input string) (output string, outputIsError bool, retErr 
 	}()
 
 	var d interface{}
-	if _, err := toml.Decode(input, &d); err != nil {
+	meta, err := toml.Decode(input, &d)
+	if err != nil {
 		return err.Error(), true, retErr
 	}
 
-	j, err := json.MarshalIndent(tag.Add("", d), "", "  ")
+	j, err := json.MarshalIndent(tag.Add(meta, "", d), "", "  ")
 	if err != nil {
 		return "", false, err
 	}

--- a/type_toml.go
+++ b/type_toml.go
@@ -1,11 +1,136 @@
 package toml
 
-// tomlType represents any Go type that corresponds to a TOML type.
-// While the first draft of the TOML spec has a simplistic type system that
-// probably doesn't need this level of sophistication, we seem to be militating
-// toward adding real composite types.
+// tomlType represents a TOML type.
 type tomlType interface {
-	typeString() string
+	tomlType()
+	String() string
+}
+
+type TomlType = tomlType // XXX
+
+type (
+	// Bool represents a TOML boolean.
+	Bool struct{}
+
+	// String represents a TOML string.
+	String struct {
+		Literal   bool // As literal string ('..').
+		Multiline bool // As multi-line string ("""..""" or '''..''').
+	}
+
+	// Int represents a TOML integer.
+	Int struct {
+		Base  uint8 // Base 2, 8, 10, 16, or 0 (same as 10).
+		Width uint8 // Print leading zeros up to width; ignored for base 10.
+	}
+
+	// Float represents a TOML float.
+	Float struct {
+		Exponent bool // As exponent notation.
+	}
+
+	// Datetime represents a TOML datetime.
+	Datetime struct {
+		Format DatetimeFormat // enum: local, date, time
+	}
+
+	// DatetimeFormat controls the format to print a datetime.
+	DatetimeFormat uint8
+
+	// Table represents a TOML table.
+	Table struct {
+		Inline bool // As inline table.
+		//Dotted bool
+		//Merge  bool
+	}
+
+	// Array represents a TOML array.
+	Array struct {
+		SingleLine bool // Print on single line.
+	}
+
+	// ArrayTable represents a TOML array table ([[...]]).
+	ArrayTable struct {
+		Inline bool // As inline x = [{..}] rather than [[..]]
+	}
+)
+
+func (d DatetimeFormat) String() string {
+	switch d {
+	default:
+		return "<unknown>"
+	case DatetimeFormatFull:
+		return "full"
+	case DatetimeFormatLocal:
+		return "local"
+	case DatetimeFormatDate:
+		return "date"
+	case DatetimeFormatTime:
+		return "time"
+	}
+}
+
+const (
+	_                   DatetimeFormat = iota
+	DatetimeFormatFull                 // 2021-11-20T15:16:17+01:00
+	DatetimeFormatLocal                // 2021-11-20T15:16:17
+	DatetimeFormatDate                 // 2021-11-20
+	DatetimeFormatTime                 // 15:16:17
+)
+
+func (t Bool) tomlType()            {}
+func (t String) tomlType()          {}
+func (t Int) tomlType()             {}
+func (t Float) tomlType()           {}
+func (t Datetime) tomlType()        {}
+func (t Table) tomlType()           {}
+func (t Array) tomlType()           {}
+func (t ArrayTable) tomlType()      {}
+func (t Bool) String() string       { return "Bool" }
+func (t String) String() string     { return "String" }
+func (t Int) String() string        { return "Integer" }
+func (t Float) String() string      { return "Float" }
+func (t Datetime) String() string   { return "Datetime" }
+func (t Table) String() string      { return "Table" }
+func (t Array) String() string      { return "Array" }
+func (t ArrayTable) String() string { return "ArrayTable" }
+
+// meta.types may not be defined for a key, so return a zero value.
+func asString(t tomlType) String {
+	if t == nil {
+		return String{}
+	}
+	return t.(String)
+}
+func asInt(t tomlType) Int {
+	if t == nil {
+		return Int{}
+	}
+	return t.(Int)
+}
+func asFloat(t tomlType) Float {
+	if t == nil {
+		return Float{}
+	}
+	return t.(Float)
+}
+func asDatetime(t tomlType) Datetime {
+	if t == nil {
+		return Datetime{}
+	}
+	return t.(Datetime)
+}
+func asTable(t tomlType) Table {
+	if t == nil {
+		return Table{}
+	}
+	return t.(Table)
+}
+func asArray(t tomlType) Array {
+	if t == nil {
+		return Array{}
+	}
+	return t.(Array)
 }
 
 // typeEqual accepts any two types and returns true if they are equal.
@@ -13,58 +138,9 @@ func typeEqual(t1, t2 tomlType) bool {
 	if t1 == nil || t2 == nil {
 		return false
 	}
-	return t1.typeString() == t2.typeString()
+	return t1.String() == t2.String()
 }
 
 func typeIsTable(t tomlType) bool {
-	return typeEqual(t, tomlHash) || typeEqual(t, tomlArrayHash)
-}
-
-type tomlBaseType string
-
-func (btype tomlBaseType) typeString() string {
-	return string(btype)
-}
-
-func (btype tomlBaseType) String() string {
-	return btype.typeString()
-}
-
-var (
-	tomlInteger   tomlBaseType = "Integer"
-	tomlFloat     tomlBaseType = "Float"
-	tomlDatetime  tomlBaseType = "Datetime"
-	tomlString    tomlBaseType = "String"
-	tomlBool      tomlBaseType = "Bool"
-	tomlArray     tomlBaseType = "Array"
-	tomlHash      tomlBaseType = "Hash"
-	tomlArrayHash tomlBaseType = "ArrayHash"
-)
-
-// typeOfPrimitive returns a tomlType of any primitive value in TOML.
-// Primitive values are: Integer, Float, Datetime, String and Bool.
-//
-// Passing a lexer item other than the following will cause a BUG message
-// to occur: itemString, itemBool, itemInteger, itemFloat, itemDatetime.
-func (p *parser) typeOfPrimitive(lexItem item) tomlType {
-	switch lexItem.typ {
-	case itemInteger:
-		return tomlInteger
-	case itemFloat:
-		return tomlFloat
-	case itemDatetime:
-		return tomlDatetime
-	case itemString:
-		return tomlString
-	case itemMultilineString:
-		return tomlString
-	case itemRawString:
-		return tomlString
-	case itemRawMultilineString:
-		return tomlString
-	case itemBool:
-		return tomlBool
-	}
-	p.bug("Cannot infer primitive type of lex item '%s'.", lexItem)
-	panic("unreachable")
+	return typeEqual(t, Table{}) || typeEqual(t, ArrayTable{})
 }


### PR DESCRIPTION
This allows encoding comments and setting some flags to control the
format. While toml.Marshaler added in #327 gives full control over how
you want to format something, I don't think it's especially
user-friendly to tell everyone to create a new type with all the
appropriate formatting, escaping, etc. The vast majority of of use cases
probably just call in to a few simple categories such as "use `"""` or
"encode this number as a hex".

I grouped both features together as they're closely related: both set
additional information on how to write keys.

What I want is something that:

1. allows setting attributes programmatically;
2. supports round-tripping by default on a standard struct;
3. plays well with other encoders/decoders;
4. has a reasonable uncumbersome API.

Most options (custom types, struct tags) fail at least one of these;
there were some PRs for struct tags, but they fail at 1, 2, and
(arguably) 4. Custom types fail at 2, 3, and probably 4.

---

This adds SetMeta() to the Encoder type; this is already what we have
when decoding, and all additional information will be set on it. On
MetaData we add the following types:

    SetType()       Set TOML type info.
    TypeInfo()      Get TOML type info.
    Doc()           Set "doc comment" above the key.
    Comment()       Set "inline comment" after the key.

Every TOML type has a type in this package, which support different
formatting options (see type_toml.go):

    Bool
    String
    Int
    Float
    Datetime
    Table
    Array
    ArrayTable

For example:

    meta := toml.NewMetaData().
            SetType("key", toml.Int{Width: 4, Base: 16}).
            Doc("key", "A codepoint").
    Comment("key", "ë")
    toml.NewEncoder(os.Stdout).SetMeta(meta).Encode(struct {
            Key string `toml:"key"`
    }{"ë")

Would write:

    # A codepoint.
    key = 0x00eb  # ë

It also has Key() to set both:

    toml.NewMetaData().
        Key("key", toml.Int{Width: 4, Base: 16}, toml.Doc("A codepoint"), toml.Comment("ë")).
        Key("other", toml.Comment("..."))

The advantage of this is that it reduces the number of times you have to
type the key string to 1, but it uses interface{}. Not yet decided which
one I'll stick with, and also not a huge fan of Doc() and Comment(), but
I can't really think of anything clearer at the moment (these are the
names the Go ast uses).

---

The Decode() sets all this information on the MetaData, so this:

    meta, _ := toml.Decode(..)
    toml.NewEncoder(os.Stdout).SetMeta(meta).Encode(..)

Will write it out as "key = 0x00eb" again, rather than "key = 235".

This way, pretty much any flag can be added programmatically without
getting in the way of JSON/YAML/whatnot encoding/decoding.

---

I don't especially care how you need to pass the keys as strings, but
there isn't really any good way to do it otherwise. There is also the
problem that the "key" as found in the parser may be different than the
"key" the user is expecting if you don't use toml struct tags:

    type X struct { Key int }

Will read "key = 2" in to "Key", but when encoding it will write as
"Key" rather than "key". The type information will be set to "key", but
when encoding it will look for "Key", so round-tripping won't work
correct and has the potential for confusion if the wrong key is set.

This is not so easy to fix since we don't have access to the struct in
the parser. I think it's fine to just document this as a caveat and tell
people to use struct tags, which is a good idea in any case.

---

I'm not necessarily opposed to also adding struct tags for most of these
things, although I'm not a huge fan of them. Since struct tags can't be
set programmatically it's not really suitable for many use cases (e.g.
setting comments dynamically, using multiline strings only if the string
contains newlines, etc.) It's something that could maybe be added in a
future PR, if a lot of people ask for it.

Fixes #64
Fixes #75
Fixes #160
Fixes #192
Fixes #213
Fixes #269
