### PR TITLE
Decode S=[] into a non-nil []interface{}.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -618,6 +618,17 @@ func TestDecodeSlices(t *testing.T) {
 	}
 }
 
+func TestDecodeInterfaceSlice(t *testing.T) {
+	var v map[string]interface{}
+	if _, err := Decode(`S = []`, &v); err != nil {
+		t.Errorf(err.Error())
+	}
+	// S = [] should decode into a non-nil []interface{} (see issue #338).
+	if reflect.ValueOf(v["S"]).IsNil() {
+		t.Errorf("S is nil")
+	}
+}
+
 func TestDecodePrimitive(t *testing.T) {
 	type S struct {
 		P Primitive

--- a/parse.go
+++ b/parse.go
@@ -350,6 +350,10 @@ func (p *parser) valueArray(it item) (interface{}, tomlType) {
 		array []interface{}
 		types []tomlType
 	)
+	// Initialize to a non-nil empty slice. This makes it
+	// consistent with how S = [] decodes into a non-nil slice
+	// inside something like struct { S []string }.
+	array = []interface{}{}
 	for it = p.next(); it.typ != itemArrayEnd; it = p.next() {
 		if it.typ == itemCommentStart {
 			p.expect(itemText)


### PR DESCRIPTION
This restores v0.3 behaviour and also makes it
consistent with how the same decodes into something
like struct { S []string }.

Closes #338