### PR TITLE
Support time.Duration string format

### DIFF
--- a/_example/example.go
+++ b/_example/example.go
@@ -18,7 +18,7 @@ type (
 		Integers   []int
 		Floats     []float64
 		Times      []fmtTime
-		Duration   []duration
+		Duration   []time.Duration
 		Distros    []distro
 		Servers    map[string]server
 		Characters map[string][]struct {
@@ -38,14 +38,8 @@ type (
 		Packages string
 	}
 
-	duration struct{ time.Duration }
-	fmtTime  struct{ time.Time }
+	fmtTime struct{ time.Time }
 )
-
-func (d *duration) UnmarshalText(text []byte) (err error) {
-	d.Duration, err = time.ParseDuration(string(text))
-	return err
-}
 
 func (t fmtTime) String() string {
 	f := "2006-01-02 15:04:05.999999999"

--- a/_example/example.toml
+++ b/_example/example.toml
@@ -20,7 +20,7 @@ times = [
 	15:16:17,                   # local time.
 ]
 
-# Custom Unmarshal.
+# Durations.
 duration = ["4m49s", "8m03s", "1231h15m55s"]
 
 # Table with inline tables.

--- a/bench_test.go
+++ b/bench_test.go
@@ -169,14 +169,14 @@ type (
 		Packages string
 	}
 
-	//duration struct{ time.Duration }
-	fmtTime struct{ time.Time }
+	duration struct{ time.Duration }
+	fmtTime  struct{ time.Time }
 )
 
-//func (d *duration) UnmarshalText(text []byte) (err error) {
-//	d.Duration, err = time.ParseDuration(string(text))
-//	return err
-//}
+func (d *duration) UnmarshalText(text []byte) (err error) {
+	d.Duration, err = time.ParseDuration(string(text))
+	return err
+}
 
 func (t fmtTime) String() string {
 	f := "2006-01-02 15:04:05.999999999"

--- a/decode.go
+++ b/decode.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 )
 
 // Unmarshaler is the interface implemented by objects that can unmarshal a
@@ -419,6 +420,17 @@ func (md *MetaData) unifyFloat64(data interface{}, rv reflect.Value) error {
 }
 
 func (md *MetaData) unifyInt(data interface{}, rv reflect.Value) error {
+	if _, ok := rv.Interface().(time.Duration); ok {
+		if s, ok := data.(string); ok {
+			dur, err := time.ParseDuration(s)
+			if err != nil {
+				return e("value %q is not a valid duration: %w", s, err)
+			}
+			rv.SetInt(int64(dur))
+			return nil
+		}
+	}
+
 	if num, ok := data.(int64); ok {
 		if rv.Kind() >= reflect.Int && rv.Kind() <= reflect.Int64 {
 			switch rv.Kind() {

--- a/decode.go
+++ b/decode.go
@@ -76,6 +76,9 @@ const (
 // TOML datetimes correspond to Go time.Time values. Local datetimes are parsed
 // in the local timezone.
 //
+// time.Duration types are treated as nanoseconds if the TOML value is an
+// integer, or they're parsed with time.ParseDuration() if they're strings.
+//
 // All other TOML types (float, string, int, bool and array) correspond to the
 // obvious Go types.
 //
@@ -83,7 +86,7 @@ const (
 // interface, in which case any primitive TOML value (floats, strings, integers,
 // booleans, datetimes) will be converted to a []byte and given to the value's
 // UnmarshalText method. See the Unmarshaler example for a demonstration with
-// time duration strings.
+// email addresses.
 //
 // Key mapping
 //

--- a/decode_test.go
+++ b/decode_test.go
@@ -815,14 +815,21 @@ func TestDecodeDuration(t *testing.T) {
 		{`t = 0`, 0, ""},
 		{`t = 12345678`, 12345678, ""},
 
+		{`t = "99 bottles of beer"`, 0, `unknown unit " bottles of beer" in duration "99 bottles of beer"`},
+		{`t = "one bottle of beer"`, 0, `invalid duration "one bottle of beer"`},
 		{`t = 1.2`, 0, "incompatible types"},
 		{`t = {}`, 0, "incompatible types"},
 		{`t = []`, 0, "incompatible types"},
+
+		// TODO: also test *time.Duration, map[string]time.Duration
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			var have struct{ T time.Duration }
+			var have struct {
+				T time.Duration
+				D time.Time
+			}
 
 			_, err := Decode(tt.toml, &have)
 			if !errorContains(err, tt.wantErr) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -267,6 +267,34 @@ func TestDecodeIntOverflow(t *testing.T) {
 	}
 }
 
+func TestDecodeStringDuration(t *testing.T) {
+	type table struct {
+		Value time.Duration
+	}
+	var tab table
+	if _, err := Decode(`value = "5m4s"`, &tab); err != nil {
+		t.Fatalf("Cannot decode duration string: %s", err)
+	}
+
+	if tab.Value != 5*time.Minute+4*time.Second {
+		t.Fatalf("Unexpected value: %q", tab.Value)
+	}
+}
+
+func TestDecodeIntegerDuration(t *testing.T) {
+	type table struct {
+		Value time.Duration
+	}
+	var tab table
+	if _, err := Decode(`value = 12345678`, &tab); err != nil {
+		t.Fatalf("Cannot decode duration integer: %s", err)
+	}
+
+	if tab.Value != 12345678 {
+		t.Fatalf("Unexpected value: %q", tab.Value)
+	}
+}
+
 func TestDecodeFloatOverflow(t *testing.T) {
 	tests := []struct {
 		value    string

--- a/encode.go
+++ b/encode.go
@@ -145,7 +145,10 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) {
 	case time.Time, encoding.TextMarshaler, Marshaler:
 		enc.writeKeyValue(key, rv, false)
 		return
-	// TODO: #76 would make this superfluous after implemented.
+		// TODO: #76 would make this superfluous after implemented.
+	case time.Duration:
+		enc.writeKeyValue(key, reflect.ValueOf(t.String()), false)
+		return
 	case Primitive:
 		enc.encode(key, reflect.ValueOf(t.undecoded))
 		return

--- a/encode.go
+++ b/encode.go
@@ -74,6 +74,9 @@ type Marshaler interface {
 // The mapping between Go values and TOML values should be precisely the same as
 // for the Decode* functions.
 //
+// time.Time is encoded as a RFC 3339 string, and time.Duration as its string
+// representation.
+//
 // The toml.Marshaler and encoder.TextMarshaler interfaces are supported to
 // encoding the value as custom TOML.
 //
@@ -136,7 +139,7 @@ func (enc *Encoder) safeEncode(key Key, rv reflect.Value) (err error) {
 }
 
 func (enc *Encoder) encode(key Key, rv reflect.Value) {
-	// Special case: time needs to be in ISO8601 format.
+	// Special case: time needs to be in RFC 3339 format.
 	//
 	// Special case: if we can marshal the type to text, then we used that. This
 	// prevents the encoder for handling these types as generic structs (or
@@ -145,10 +148,10 @@ func (enc *Encoder) encode(key Key, rv reflect.Value) {
 	case time.Time, encoding.TextMarshaler, Marshaler:
 		enc.writeKeyValue(key, rv, false)
 		return
-		// TODO: #76 would make this superfluous after implemented.
 	case time.Duration:
 		enc.writeKeyValue(key, reflect.ValueOf(t.String()), false)
 		return
+	// TODO: #76 would make this superfluous after implemented.
 	case Primitive:
 		enc.encode(key, reflect.ValueOf(t.undecoded))
 		return

--- a/encode_test.go
+++ b/encode_test.go
@@ -268,26 +268,6 @@ func TestEncodeNaN(t *testing.T) {
 	encodeExpected(t, "", s2, "nan = nan\ninf = -inf\n", nil)
 }
 
-func TestEncodeDuration(t *testing.T) {
-	cases := []time.Duration{
-		0,
-		time.Second,
-		time.Minute,
-		time.Hour,
-		248*time.Hour + 45*time.Minute + 24*time.Second,
-		12345678 * time.Nanosecond,
-		12345678 * time.Second,
-	}
-
-	for _, d := range cases {
-		encodeExpected(t, d.String(), struct {
-			Dur time.Duration
-		}{
-			Dur: d,
-		}, fmt.Sprintf("Dur = %q", d), nil)
-	}
-}
-
 func TestEncodePrimitive(t *testing.T) {
 	type MyStruct struct {
 		Data  Primitive
@@ -514,6 +494,25 @@ func TestEncodeSkipInvalidType(t *testing.T) {
 	want := "str = \"a\"\n"
 	if have != want {
 		t.Errorf("\nwant: %q\nhave: %q\n", want, have)
+	}
+}
+
+func TestEncodeDuration(t *testing.T) {
+	tests := []time.Duration{
+		0,
+		time.Second,
+		time.Minute,
+		time.Hour,
+		248*time.Hour + 45*time.Minute + 24*time.Second,
+		12345678 * time.Nanosecond,
+		12345678 * time.Second,
+		4*time.Second + 2*time.Nanosecond,
+	}
+
+	for _, tt := range tests {
+		encodeExpected(t, tt.String(),
+			struct{ Dur time.Duration }{Dur: tt},
+			fmt.Sprintf("Dur = %q", tt), nil)
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -268,6 +268,26 @@ func TestEncodeNaN(t *testing.T) {
 	encodeExpected(t, "", s2, "nan = nan\ninf = -inf\n", nil)
 }
 
+func TestEncodeDuration(t *testing.T) {
+	cases := []time.Duration{
+		0,
+		time.Second,
+		time.Minute,
+		time.Hour,
+		248*time.Hour + 45*time.Minute + 24*time.Second,
+		12345678 * time.Nanosecond,
+		12345678 * time.Second,
+	}
+
+	for _, d := range cases {
+		encodeExpected(t, d.String(), struct {
+			Dur time.Duration
+		}{
+			Dur: d,
+		}, fmt.Sprintf("Dur = %q", d), nil)
+	}
+}
+
 func TestEncodePrimitive(t *testing.T) {
 	type MyStruct struct {
 		Data  Primitive

--- a/example_test.go
+++ b/example_test.go
@@ -4,23 +4,26 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"net/mail"
 	"time"
 
 	"github.com/BurntSushi/toml"
 )
 
 func ExampleEncoder_Encode() {
-	date, _ := time.Parse(time.RFC822, "14 Mar 10 18:00 UTC")
-	var config = map[string]interface{}{
+	var (
+		date, _ = time.Parse(time.RFC822, "14 Mar 10 18:00 UTC")
+		buf     = new(bytes.Buffer)
+	)
+	err := toml.NewEncoder(buf).Encode(map[string]interface{}{
 		"date":   date,
 		"counts": []int{1, 1, 2, 3, 5, 8},
 		"hash": map[string]string{
 			"key1": "val1",
 			"key2": "val2",
 		},
-	}
-	buf := new(bytes.Buffer)
-	if err := toml.NewEncoder(buf).Encode(config); err != nil {
+	})
+	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println(buf.String())
@@ -35,33 +38,33 @@ func ExampleEncoder_Encode() {
 }
 
 func ExampleMetaData_PrimitiveDecode() {
-	var md toml.MetaData
-	var err error
+	tomlBlob := `
+		ranking = ["Springsteen", "J Geils"]
 
-	var tomlBlob = `
-ranking = ["Springsteen", "J Geils"]
+		[bands.Springsteen]
+		started = 1973
+		albums = ["Greetings", "WIESS", "Born to Run", "Darkness"]
 
-[bands.Springsteen]
-started = 1973
-albums = ["Greetings", "WIESS", "Born to Run", "Darkness"]
+		[bands."J Geils"]
+		started = 1970
+		albums = ["The J. Geils Band", "Full House", "Blow Your Face Out"]
+		`
 
-[bands."J Geils"]
-started = 1970
-albums = ["The J. Geils Band", "Full House", "Blow Your Face Out"]
-`
+	type (
+		band struct {
+			Started int
+			Albums  []string
+		}
+		classics struct {
+			Ranking []string
+			Bands   map[string]toml.Primitive
+		}
+	)
 
-	type band struct {
-		Started int
-		Albums  []string
-	}
-	type classics struct {
-		Ranking []string
-		Bands   map[string]toml.Primitive
-	}
-
-	// Do the initial decode. Reflection is delayed on Primitive values.
+	// Do the initial decode; reflection is delayed on Primitive values.
 	var music classics
-	if md, err = toml.Decode(tomlBlob, &music); err != nil {
+	md, err := toml.Decode(tomlBlob, &music)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -71,18 +74,20 @@ albums = ["The J. Geils Band", "Full House", "Blow Your Face Out"]
 
 	// Decode primitive data into Go values.
 	for _, artist := range music.Ranking {
-		// A band is a primitive value, so we need to decode it to get a
-		// real `band` value.
+		// A band is a primitive value, so we need to decode it to get a real
+		// `band` value.
 		primValue := music.Bands[artist]
 
 		var aBand band
-		if err = md.PrimitiveDecode(primValue, &aBand); err != nil {
+		err = md.PrimitiveDecode(primValue, &aBand)
+		if err != nil {
 			log.Fatal(err)
 		}
 		fmt.Printf("%s started in %d.\n", artist, aBand.Started)
 	}
-	// Check to see if there were any fields left undecoded.
-	// Note that this won't be empty before decoding the Primitive value!
+
+	// Check to see if there were any fields left undecoded. Note that this
+	// won't be empty before decoding the Primitive value!
 	fmt.Printf("Undecoded: %q\n", md.Undecoded())
 
 	// Output:
@@ -93,40 +98,41 @@ albums = ["The J. Geils Band", "Full House", "Blow Your Face Out"]
 }
 
 func ExampleDecode() {
-	var tomlBlob = `
-# Some comments.
-[alpha]
-ip = "10.0.0.1"
+	tomlBlob := `
+		# Some comments.
+		[alpha]
+		ip = "10.0.0.1"
 
-	[alpha.config]
-	Ports = [ 8001, 8002 ]
-	Location = "Toronto"
-	Created = 1987-07-05T05:45:00Z
+			[alpha.config]
+			Ports = [ 8001, 8002 ]
+			Location = "Toronto"
+			Created = 1987-07-05T05:45:00Z
 
-[beta]
-ip = "10.0.0.2"
+		[beta]
+		ip = "10.0.0.2"
 
-	[beta.config]
-	Ports = [ 9001, 9002 ]
-	Location = "New Jersey"
-	Created = 1887-01-05T05:55:00Z
-`
+			[beta.config]
+			Ports = [ 9001, 9002 ]
+			Location = "New Jersey"
+			Created = 1887-01-05T05:55:00Z
+	`
 
-	type serverConfig struct {
-		Ports    []int
-		Location string
-		Created  time.Time
-	}
-
-	type server struct {
-		IP     string       `toml:"ip,omitempty"`
-		Config serverConfig `toml:"config"`
-	}
-
-	type servers map[string]server
+	type (
+		serverConfig struct {
+			Ports    []int
+			Location string
+			Created  time.Time
+		}
+		server struct {
+			IP     string       `toml:"ip,omitempty"`
+			Config serverConfig `toml:"config"`
+		}
+		servers map[string]server
+	)
 
 	var config servers
-	if _, err := toml.Decode(tomlBlob, &config); err != nil {
+	_, err := toml.Decode(tomlBlob, &config)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -145,13 +151,11 @@ ip = "10.0.0.2"
 	// Ports: [9001 9002]
 }
 
-type duration struct {
-	time.Duration
-}
+type address struct{ *mail.Address }
 
-func (d *duration) UnmarshalText(text []byte) error {
+func (a *address) UnmarshalText(text []byte) error {
 	var err error
-	d.Duration, err = time.ParseDuration(string(text))
+	a.Address, err = mail.ParseAddress(string(text))
 	return err
 }
 
@@ -159,66 +163,60 @@ func (d *duration) UnmarshalText(text []byte) error {
 // custom data type.
 func Example_unmarshaler() {
 	blob := `
-[[song]]
-name = "Thunder Road"
-duration = "4m49s"
+		contacts = [
+			"Donald Duck <donald@duckburg.com>",
+			"Scrooge McDuck <scrooge@duckburg.com>",
+		]
+	`
 
-[[song]]
-name = "Stairway to Heaven"
-duration = "8m03s"
-`
-	type song struct {
-		Name     string
-		Duration duration
+	var contacts struct {
+		// Implementation of the address type:
+		//
+		//     type address struct{ *mail.Address }
+		//
+		//     func (a *address) UnmarshalText(text []byte) error {
+		//         var err error
+		//         a.Address, err = mail.ParseAddress(string(text))
+		//         return err
+		//     }
+
+		Contacts []address
 	}
-	type songs struct {
-		Song []song
-	}
-	var favorites songs
-	if _, err := toml.Decode(blob, &favorites); err != nil {
+
+	_, err := toml.Decode(blob, &contacts)
+	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Code to implement the TextUnmarshaler interface for `duration`:
-	//
-	// type duration struct {
-	// 	time.Duration
-	// }
-	//
-	// func (d *duration) UnmarshalText(text []byte) error {
-	// 	var err error
-	// 	d.Duration, err = time.ParseDuration(string(text))
-	// 	return err
-	// }
-
-	for _, s := range favorites.Song {
-		fmt.Printf("%s (%s)\n", s.Name, s.Duration)
+	for _, c := range contacts.Contacts {
+		fmt.Printf("%#v\n", c.Address)
 	}
+
 	// Output:
-	// Thunder Road (4m49s)
-	// Stairway to Heaven (8m3s)
+	// &mail.Address{Name:"Donald Duck", Address:"donald@duckburg.com"}
+	// &mail.Address{Name:"Scrooge McDuck", Address:"scrooge@duckburg.com"}
 }
 
-// Example StrictDecoding shows how to detect whether there are keys in the
-// TOML document that weren't decoded into the value given. This is useful
-// for returning an error to the user if they've included extraneous fields
-// in their configuration.
+// Example StrictDecoding shows how to detect if there are keys in the TOML
+// document that weren't decoded into the value given. This is useful for
+// returning an error to the user if they've included extraneous fields in their
+// configuration.
 func Example_strictDecoding() {
 	var blob = `
-key1 = "value1"
-key2 = "value2"
-key3 = "value3"
-`
-	type config struct {
+		key1 = "value1"
+		key2 = "value2"
+		key3 = "value3"
+	`
+
+	var conf struct {
 		Key1 string
 		Key3 string
 	}
-
-	var conf config
 	md, err := toml.Decode(blob, &conf)
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	fmt.Printf("Undecoded keys: %q\n", md.Undecoded())
 	// Output:
 	// Undecoded keys: ["key2"]
@@ -271,10 +269,9 @@ func (c *cable) Name() string {
 }
 
 func (o *order) UnmarshalTOML(data interface{}) error {
-
-	// NOTE the example below contains detailed type casting to show how
-	// the 'data' is retrieved. In operational use, a type cast wrapper
-	// may be preferred e.g.
+	// NOTE the example below contains detailed type casting to show how the
+	// 'data' is retrieved. In operational use, a type cast wrapper may be
+	// preferred e.g.
 	//
 	// func AsMap(v interface{}) (map[string]interface{}, error) {
 	// 		return v.(map[string]interface{})
@@ -348,169 +345,43 @@ func (o *order) UnmarshalTOML(data interface{}) error {
 // struct in cases where the actual type is not known until the data is
 // examined.
 func Example_unmarshalTOML() {
+	blob := `
+		[[parts]]
+		type = "valve"
+		id = "valve-1"
+		size = 1.2
+		rating = 4
 
-	var blob = `
-[[parts]]
-type = "valve"
-id = "valve-1"
-size = 1.2
-rating = 4
+		[[parts]]
+		type = "valve"
+		id = "valve-2"
+		size = 2.1
+		rating = 5
 
-[[parts]]
-type = "valve"
-id = "valve-2"
-size = 2.1
-rating = 5
+		[[parts]]
+		type = "pipe"
+		id = "pipe-1"
+		length = 2.1
+		diameter = 12
 
-[[parts]]
-type = "pipe"
-id = "pipe-1"
-length = 2.1
-diameter = 12
+		[[parts]]
+		type = "cable"
+		id = "cable-1"
+		length = 12
+		rating = 3.1
+	`
 
-[[parts]]
-type = "cable"
-id = "cable-1"
-length = 12
-rating = 3.1
-`
+	// See example_test.go in the source for the implementation of the order
+	// type.
 	o := &order{}
+
 	err := toml.Unmarshal([]byte(blob), o)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	fmt.Println(len(o.parts))
-
 	for _, part := range o.parts {
 		fmt.Println(part.Name())
 	}
-
-	// Code to implement UmarshalJSON.
-
-	// type order struct {
-	// 	// NOTE `order.parts` is a private slice of type `part` which is an
-	// 	// interface and may only be loaded from toml using the
-	// 	// UnmarshalTOML() method of the Umarshaler interface.
-	// 	parts parts
-	// }
-
-	// func (o *order) UnmarshalTOML(data interface{}) error {
-
-	// 	// NOTE the example below contains detailed type casting to show how
-	// 	// the 'data' is retrieved. In operational use, a type cast wrapper
-	// 	// may be preferred e.g.
-	// 	//
-	// 	// func AsMap(v interface{}) (map[string]interface{}, error) {
-	// 	// 		return v.(map[string]interface{})
-	// 	// }
-	// 	//
-	// 	// resulting in:
-	// 	// d, _ := AsMap(data)
-	// 	//
-
-	// 	d, _ := data.(map[string]interface{})
-	// 	parts, _ := d["parts"].([]map[string]interface{})
-
-	// 	for _, p := range parts {
-
-	// 		typ, _ := p["type"].(string)
-	// 		id, _ := p["id"].(string)
-
-	// 		// detect the type of part and handle each case
-	// 		switch p["type"] {
-	// 		case "valve":
-
-	// 			size := float32(p["size"].(float64))
-	// 			rating := int(p["rating"].(int64))
-
-	// 			valve := &valve{
-	// 				Type:   typ,
-	// 				ID:     id,
-	// 				Size:   size,
-	// 				Rating: rating,
-	// 			}
-
-	// 			o.parts = append(o.parts, valve)
-
-	// 		case "pipe":
-
-	// 			length := float32(p["length"].(float64))
-	// 			diameter := int(p["diameter"].(int64))
-
-	// 			pipe := &pipe{
-	// 				Type:     typ,
-	// 				ID:       id,
-	// 				Length:   length,
-	// 				Diameter: diameter,
-	// 			}
-
-	// 			o.parts = append(o.parts, pipe)
-
-	// 		case "cable":
-
-	// 			length := int(p["length"].(int64))
-	// 			rating := float32(p["rating"].(float64))
-
-	// 			cable := &cable{
-	// 				Type:   typ,
-	// 				ID:     id,
-	// 				Length: length,
-	// 				Rating: rating,
-	// 			}
-
-	// 			o.parts = append(o.parts, cable)
-
-	// 		}
-	// 	}
-
-	// 	return nil
-	// }
-
-	// type parts []part
-
-	// type part interface {
-	// 	Name() string
-	// }
-
-	// type valve struct {
-	// 	Type   string
-	// 	ID     string
-	// 	Size   float32
-	// 	Rating int
-	// }
-
-	// func (v *valve) Name() string {
-	// 	return fmt.Sprintf("VALVE: %s", v.ID)
-	// }
-
-	// type pipe struct {
-	// 	Type     string
-	// 	ID       string
-	// 	Length   float32
-	// 	Diameter int
-	// }
-
-	// func (p *pipe) Name() string {
-	// 	return fmt.Sprintf("PIPE: %s", p.ID)
-	// }
-
-	// type cable struct {
-	// 	Type   string
-	// 	ID     string
-	// 	Length int
-	// 	Rating float32
-	// }
-
-	// func (c *cable) Name() string {
-	// 	return fmt.Sprintf("CABLE: %s", c.ID)
-	// }
-
-	// Output:
-	// 4
-	// VALVE: valve-1
-	// VALVE: valve-2
-	// PIPE: pipe-1
-	// CABLE: cable-1
-
 }


### PR DESCRIPTION
Using numeric representation of time.Duration is confusing, because
value is stored as UNIX nanoseconds. Humans tend to be more comfortable
with the string representation of the time.Duration.

In addition to time.Duration being an int64 number and encoding/decoding
as such, allow to use its string representation. For example, the below
structure:

    Configuration := struct {
    	ExpireIn time.Duration
    }{
    	ExpireIn 15 * time.Minute,
    }

Is currently serialized as:

    ExpireIn = 900000000000

This commit is prioritizing its string representation and the new
encoding will produce:

    ExpireIn = "15m0s"

This change is backward compatible. Both old numeric value and the new
string reprentation are accepted by the decoder.