### PR TITLE
Fix test on 32 bit arch

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -42,8 +42,8 @@ type Primitive struct {
 // The significand precision for float32 and float64 is 24 and 53 bits; this is
 // the range a natural number can be stored in a float without loss of data.
 const (
-	maxSafeFloat32Int = 16777215         // 2^24-1
-	maxSafeFloat64Int = 9007199254740991 // 2^53-1
+	maxSafeFloat32Int = 16777215                // 2^24-1
+	maxSafeFloat64Int = int64(9007199254740991) // 2^53-1
 )
 
 // PrimitiveDecode is just like the other `Decode*` functions, except it


### PR DESCRIPTION
It can be verified by running

```
$ GOARCH=386 go test ./...
# github.com/BurntSushi/toml [github.com/BurntSushi/toml.test]
./decode_test.go:281:45: constant 9007199254740992 overflows int
./decode_test.go:282:46: constant -9007199254740992 overflows int
./decode_test.go:292:16: constant 9007199254740991 overflows int
./decode_test.go:293:28: constant -9007199254740991 overflows int
FAIL    github.com/BurntSushi/toml [build failed]
?       github.com/BurntSushi/toml/cmd/toml-test-decoder        [no test files]
?       github.com/BurntSushi/toml/cmd/toml-test-encoder        [no test files]
?       github.com/BurntSushi/toml/cmd/tomlv    [no test files]
?       github.com/BurntSushi/toml/internal     [no test files]
?       github.com/BurntSushi/toml/internal/tag [no test files]
?       github.com/BurntSushi/toml/internal/toml-test   [no test files]
FAIL
```