### PR TITLE
Support IsZeroers when checking for isZero

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -612,7 +612,14 @@ func getOptions(tag reflect.StructTag) tagOptions {
 	return opts
 }
 
+type isZeroer interface {
+	IsZero() bool
+}
+
 func isZero(rv reflect.Value) bool {
+	if z, ok := rv.Interface().(isZeroer); ok {
+		return z.IsZero()
+	}
 	switch rv.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return rv.Int() == 0

--- a/encode_test.go
+++ b/encode_test.go
@@ -165,6 +165,22 @@ unsigned = 5
 	encodeExpected(t, "simple with omitzero, non-zero", value, expected, nil)
 }
 
+func TestEncodeWithOmitZeroWithIsZeroer(t *testing.T) {
+	type simple struct {
+		Time time.Time `toml:"time,omitzero"`
+	}
+
+	value := simple{time.Time{}}
+	expected := ""
+
+	encodeExpected(t, "simple with omitzero, iszeroer, zero", value, expected, nil)
+
+	value.Time = time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)
+	expected = `time = 2006-01-02T15:04:05Z
+`
+	encodeExpected(t, "simple with omitzero, iszeroer, non-zero", value, expected, nil)
+}
+
 func TestEncodeOmitemptyWithEmptyName(t *testing.T) {
 	type simple struct {
 		S []int `toml:",omitempty"`


### PR DESCRIPTION
Expanding the capabilities of `omitzero` by allowing to check if the value implements the `isZeroer` interface below:

```go
type isZeroer interface {
  IsZero() bool
}
```

This enables values, such as of the type `time.Time`, to be treated as expected when they have a zero value.