### PR TITLE
fix decode in mapvalue, md.unify should use with indirect type

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -198,13 +198,14 @@ func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 		return nil
 	}
 
+	rvi := rv.Interface()
 	// Special case. Unmarshaler Interface support.
-	if v, ok := rv.Interface().(Unmarshaler); ok {
+	if v, ok := rvi.(Unmarshaler); ok {
 		return v.UnmarshalTOML(data)
 	}
 
 	// Special case. Look for a value satisfying the TextUnmarshaler interface.
-	if v, ok := rv.Interface().(encoding.TextUnmarshaler); ok {
+	if v, ok := rvi.(encoding.TextUnmarshaler); ok {
 		return md.unifyText(data, v)
 	}
 	// TODO:
@@ -224,7 +225,7 @@ func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 	switch k {
 	case reflect.Ptr:
 		elem := reflect.New(rv.Type().Elem())
-		err := md.unify(data, indirect(elem))
+		err := md.unify(data, reflect.Indirect(elem))
 		if err != nil {
 			return err
 		}

--- a/decode.go
+++ b/decode.go
@@ -111,6 +111,7 @@ func NewDecoder(r io.Reader) *Decoder {
 var (
 	unmarshalToml = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
 	unmarshalText = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	primitiveType = reflect.TypeOf((*Primitive)(nil)).Elem()
 )
 
 // Decode TOML data in to the pointer `v`.
@@ -185,7 +186,7 @@ func (md *MetaData) PrimitiveDecode(primValue Primitive, v interface{}) error {
 func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 	// Special case. Look for a `Primitive` value.
 	// TODO: #76 would make this superfluous after implemented.
-	if rv.Type() == reflect.TypeOf((*Primitive)(nil)).Elem() {
+	if rv.Type() == primitiveType {
 		// Save the undecoded data and the key context into the primitive
 		// value.
 		context := make(Key, len(md.context))
@@ -198,10 +199,8 @@ func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 	}
 
 	// Special case. Unmarshaler Interface support.
-	if rv.CanAddr() {
-		if v, ok := rv.Addr().Interface().(Unmarshaler); ok {
-			return v.UnmarshalTOML(data)
-		}
+	if v, ok := rv.Interface().(Unmarshaler); ok {
+		return v.UnmarshalTOML(data)
 	}
 
 	// Special case. Look for a value satisfying the TextUnmarshaler interface.
@@ -225,7 +224,7 @@ func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 	switch k {
 	case reflect.Ptr:
 		elem := reflect.New(rv.Type().Elem())
-		err := md.unify(data, reflect.Indirect(elem))
+		err := md.unify(data, indirect(elem))
 		if err != nil {
 			return err
 		}
@@ -322,7 +321,7 @@ func (md *MetaData) unifyMap(mapping interface{}, rv reflect.Value) error {
 		md.context = append(md.context, k)
 
 		rvval := reflect.Indirect(reflect.New(rv.Type().Elem()))
-		if err := md.unify(v, rvval); err != nil {
+		if err := md.unify(v, indirect(rvval)); err != nil {
 			return err
 		}
 		md.context = md.context[0 : len(md.context)-1]
@@ -534,7 +533,11 @@ func indirect(v reflect.Value) reflect.Value {
 	if v.Kind() != reflect.Ptr {
 		if v.CanSet() {
 			pv := v.Addr()
-			if _, ok := pv.Interface().(encoding.TextUnmarshaler); ok {
+			pvi := pv.Interface()
+			if _, ok := pvi.(encoding.TextUnmarshaler); ok {
+				return pv
+			}
+			if _, ok := pvi.(Unmarshaler); ok {
 				return pv
 			}
 		}
@@ -550,7 +553,11 @@ func isUnifiable(rv reflect.Value) bool {
 	if rv.CanSet() {
 		return true
 	}
-	if _, ok := rv.Interface().(encoding.TextUnmarshaler); ok {
+	rvi := rv.Interface()
+	if _, ok := rvi.(encoding.TextUnmarshaler); ok {
+		return true
+	}
+	if _, ok := rvi.(Unmarshaler); ok {
 		return true
 	}
 	return false

--- a/decode.go
+++ b/decode.go
@@ -199,15 +199,13 @@ func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 	}
 
 	rvi := rv.Interface()
-	// Special case. Unmarshaler Interface support.
 	if v, ok := rvi.(Unmarshaler); ok {
 		return v.UnmarshalTOML(data)
 	}
-
-	// Special case. Look for a value satisfying the TextUnmarshaler interface.
 	if v, ok := rvi.(encoding.TextUnmarshaler); ok {
 		return md.unifyText(data, v)
 	}
+
 	// TODO:
 	// The behavior here is incorrect whenever a Go type satisfies the
 	// encoding.TextUnmarshaler interface but also corresponds to a TOML hash or

--- a/decode_test.go
+++ b/decode_test.go
@@ -197,7 +197,6 @@ func TestDecodePointers(t *testing.T) {
 		BaseObject  *Object
 		Strptr      *string
 		Strptrs     []*string
-		TimeMap     map[string]time.Time
 	}
 	s1, s2, s3 := "blah", "abc", "def"
 	expected := &Dict{
@@ -208,9 +207,6 @@ func TestDecodePointers(t *testing.T) {
 			"bar": {"BAR", "ba-ba-ba-ba-barrrr!!!"},
 		},
 		BaseObject: &Object{"BASE", "da base"},
-		TimeMap: map[string]time.Time{
-			"foo": time.Date(1987, 7, 5, 5, 45, 0, 0, time.UTC),
-		},
 	}
 
 	ex1 := `
@@ -228,9 +224,6 @@ Description = "ba-ba-ba-ba-barrrr!!!"
 [BaseObject]
 Type = "BASE"
 Description = "da base"
-
-[TimeMap]
-foo = 1987-07-05T05:45:00Z
 `
 	dict := new(Dict)
 	_, err := Decode(ex1, dict)
@@ -758,6 +751,38 @@ func TestDecodeDatetime(t *testing.T) {
 				t.Errorf("\nhave: %s\nwant: %s", h, w)
 			}
 		})
+	}
+}
+
+func TestDecodeTextUnmarshaler(t *testing.T) {
+	type Dict struct {
+		Time    time.Time
+		TimeP   *time.Time
+		TimeMap map[string]time.Time
+	}
+
+	tm := time.Date(1987, 7, 5, 5, 45, 0, 0, time.UTC)
+	expected := &Dict{
+		Time:    tm,
+		TimeP:   &tm,
+		TimeMap: map[string]time.Time{"foo": tm},
+	}
+
+	ex1 := `
+Time = 1987-07-05T05:45:00Z
+TimeP = 1987-07-05T05:45:00Z
+
+[TimeMap]
+foo = 1987-07-05T05:45:00Z
+`
+
+	dict := new(Dict)
+	_, err := Decode(ex1, dict)
+	if err != nil {
+		t.Errorf("Decode error: %v", err)
+	}
+	if !reflect.DeepEqual(expected, dict) {
+		t.Fatalf("\n%#v\n!=\n%#v\n", expected, dict)
 	}
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -197,6 +197,7 @@ func TestDecodePointers(t *testing.T) {
 		BaseObject  *Object
 		Strptr      *string
 		Strptrs     []*string
+		TimeMap     map[string]time.Time
 	}
 	s1, s2, s3 := "blah", "abc", "def"
 	expected := &Dict{
@@ -207,6 +208,9 @@ func TestDecodePointers(t *testing.T) {
 			"bar": {"BAR", "ba-ba-ba-ba-barrrr!!!"},
 		},
 		BaseObject: &Object{"BASE", "da base"},
+		TimeMap: map[string]time.Time{
+			"foo": time.Date(1987, 7, 5, 5, 45, 0, 0, time.UTC),
+		},
 	}
 
 	ex1 := `
@@ -224,6 +228,9 @@ Description = "ba-ba-ba-ba-barrrr!!!"
 [BaseObject]
 Type = "BASE"
 Description = "da base"
+
+[TimeMap]
+foo = 1987-07-05T05:45:00Z
 `
 	dict := new(Dict)
 	_, err := Decode(ex1, dict)


### PR DESCRIPTION
fixed some inconsistencies 😊
including but not limited to "Unmarshal to  map[string]time.time"

BTW: cuz indirect func, the reflect.Ptr switch in md.unify maybe a dead code 😂