### PR TITLE
Fix encoding anonymous struct with multiple fields on 32-bit systems

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -344,6 +344,10 @@ func TestEncodeOmitemptyEmptyName(t *testing.T) {
 func TestEncodeAnonymousStruct(t *testing.T) {
 	type Inner struct{ N int }
 	type inner struct{ B int }
+	type Embedded struct {
+		Inner1 Inner
+		Inner2 Inner
+	}
 	type Outer0 struct {
 		Inner
 		inner
@@ -351,6 +355,9 @@ func TestEncodeAnonymousStruct(t *testing.T) {
 	type Outer1 struct {
 		Inner `toml:"inner"`
 		inner `toml:"innerb"`
+	}
+	type Outer3 struct {
+		Embedded
 	}
 
 	v0 := Outer0{Inner{3}, inner{4}}
@@ -360,6 +367,10 @@ func TestEncodeAnonymousStruct(t *testing.T) {
 	v1 := Outer1{Inner{3}, inner{4}}
 	expected = "[inner]\n  N = 3\n\n[innerb]\n  B = 4\n"
 	encodeExpected(t, "embedded anonymous tagged struct", v1, expected, nil)
+
+	v3 := Outer3{Embedded: Embedded{Inner{3}, Inner{4}}}
+	expected = "[Inner1]\n  N = 3\n\n[Inner2]\n  N = 4\n"
+	encodeExpected(t, "embedded anonymous multiple fields", v3, expected, nil)
 }
 
 func TestEncodeAnonymousStructPointerField(t *testing.T) {


### PR DESCRIPTION
This fixes another 32-bit edge case, which would result in the last field of an anonymous struct being duplicated for every other field within that same struct when encoded.

The fix requires a slice to be copied, which is only needed on 32-bit systems. An existing fix was done for `fieldsDirect`, but this expands to using the copied slice for `fieldsSub` too.

I've added a test case that captures the failure.

On Linux, executing `GOARCH=386 go test -run TestEncodeAnonymousStruct` without the changes done in `encode.go` results in:

```golang
--- FAIL: TestEncodeAnonymousStruct (0.00s)
    --- FAIL: TestEncodeAnonymousStruct/embedded_anonymous_multiple_fields (0.00s)
        encode_test.go:373:
            have:
                [Inner2]
                  N = 4

                [Inner2]
                  N = 4
            want:
                [Inner1]
                  N = 3

                [Inner2]
                  N = 4
```

With the changes, it works as expected.