### PR TITLE
Support \e escape character

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -17,6 +17,12 @@ import (
 	"github.com/BurntSushi/toml/internal"
 )
 
+func WithTomlNext(f func()) {
+	tomlNext = true
+	defer func() { tomlNext = false }()
+	f()
+}
+
 func TestDecodeReader(t *testing.T) {
 	var i struct{ A int }
 	meta, err := DecodeReader(strings.NewReader("a = 42"), &i)

--- a/internal/toml-test/tests/invalid/encoding/bad-utf8-in-multiline-literal.toml
+++ b/internal/toml-test/tests/invalid/encoding/bad-utf8-in-multiline-literal.toml
@@ -1,0 +1,2 @@
+# The following line contains an invalid UTF-8 sequence.
+bad = '''Ã'''

--- a/internal/toml-test/tests/invalid/encoding/bad-utf8-in-multiline.toml
+++ b/internal/toml-test/tests/invalid/encoding/bad-utf8-in-multiline.toml
@@ -1,0 +1,2 @@
+# The following line contains an invalid UTF-8 sequence.
+bad = """Ã"""

--- a/internal/toml-test/tests/invalid/encoding/bad-utf8-in-string-literal.toml
+++ b/internal/toml-test/tests/invalid/encoding/bad-utf8-in-string-literal.toml
@@ -1,0 +1,2 @@
+# The following line contains an invalid UTF-8 sequence.
+bad = 'Ã'

--- a/internal/toml-test/tests/valid/datetime/no-seconds.json
+++ b/internal/toml-test/tests/valid/datetime/no-seconds.json
@@ -1,0 +1,18 @@
+{
+  "without-seconds-1": {
+    "type": "time-local",
+    "value": "13:37:00"
+  },
+  "without-seconds-2": {
+    "type": "datetime",
+    "value": "1979-05-27T07:32:00Z"
+  },
+  "without-seconds-3": {
+    "type": "datetime",
+    "value": "1979-05-27T07:32:00-07:00"
+  },
+  "without-seconds-4": {
+    "type": "datetime-local",
+    "value": "1979-05-27T07:32:00"
+  }
+}

--- a/internal/toml-test/tests/valid/datetime/no-seconds.toml
+++ b/internal/toml-test/tests/valid/datetime/no-seconds.toml
@@ -1,0 +1,5 @@
+# Seconds are optional in date-time and time.
+without-seconds-1 = 13:37
+without-seconds-2 = 1979-05-27 07:32Z
+without-seconds-3 = 1979-05-27 07:32-07:00
+without-seconds-4 = 1979-05-27T07:32

--- a/internal/toml-test/tests/valid/string/raw-multiline.json
+++ b/internal/toml-test/tests/valid/string/raw-multiline.json
@@ -10,5 +10,9 @@
   "oneline": {
     "type": "string",
     "value": "This string has a ' quote character."
+  },
+  "multiline_with_tab": {
+    "type": "string",
+    "value": "First line\n\t Followed by a tab"
   }
 }

--- a/internal/toml-test/tests/valid/string/raw-multiline.toml
+++ b/internal/toml-test/tests/valid/string/raw-multiline.toml
@@ -12,3 +12,7 @@ has ' a quote character
 and more than
 one newline
 in it.'''
+
+# Tab character in literal string does not need to be escaped
+multiline_with_tab = '''First line
+	 Followed by a tab'''

--- a/internal/toml-test/tests/valid/string/raw.json
+++ b/internal/toml-test/tests/valid/string/raw.json
@@ -26,5 +26,9 @@
   "tab": {
     "type": "string",
     "value": "This string has a \\t tab character."
+  },
+  "unescaped_tab": {
+    "type": "string",
+    "value": "This string has an \t unescaped tab character."
   }
 }

--- a/internal/toml-test/tests/valid/string/raw.toml
+++ b/internal/toml-test/tests/valid/string/raw.toml
@@ -1,5 +1,6 @@
 backspace = 'This string has a \b backspace character.'
 tab = 'This string has a \t tab character.'
+unescaped_tab = 'This string has an 	 unescaped tab character.'
 newline = 'This string has a \n new line character.'
 formfeed = 'This string has a \f form feed character.'
 carriage = 'This string has a \r carriage return character.'

--- a/internal/toml-test/version.go
+++ b/internal/toml-test/version.go
@@ -13,7 +13,8 @@ var versions = map[string]versionSpec{
 
 	"1.0.0": versionSpec{
 		exclude: []string{
-			"valid/string/escape-esc", // \e
+			"valid/string/escape-esc",   // \e
+			"valid/datetime/no-seconds", // Times without seconds
 		},
 	},
 

--- a/lex.go
+++ b/lex.go
@@ -770,8 +770,8 @@ func lexRawString(lx *lexer) stateFn {
 	}
 }
 
-// lexMultilineRawString consumes a raw string. Nothing can be escaped in such
-// a string. It assumes that the beginning ''' has already been consumed and
+// lexMultilineRawString consumes a raw string. Nothing can be escaped in such a
+// string. It assumes that the beginning triple-' has already been consumed and
 // ignored.
 func lexMultilineRawString(lx *lexer) stateFn {
 	r := lx.next()
@@ -828,6 +828,11 @@ func lexMultilineStringEscape(lx *lexer) stateFn {
 func lexStringEscape(lx *lexer) stateFn {
 	r := lx.next()
 	switch r {
+	case 'e':
+		if !tomlNext {
+			return lx.error(errLexEscape{r})
+		}
+		fallthrough
 	case 'b':
 		fallthrough
 	case 't':

--- a/parse.go
+++ b/parse.go
@@ -10,6 +10,8 @@ import (
 	"github.com/BurntSushi/toml/internal"
 )
 
+var tomlNext = false
+
 type parser struct {
 	lx         *lexer
 	context    Key      // Full key for the current hash in scope.
@@ -744,6 +746,11 @@ func (p *parser) replaceEscapes(it item, str string) string {
 		case 'r':
 			replaced = append(replaced, rune(0x000D))
 			r += 1
+		case 'e':
+			if tomlNext {
+				replaced = append(replaced, rune(0x001B))
+				r += 1
+			}
 		case '"':
 			replaced = append(replaced, rune(0x0022))
 			r += 1


### PR DESCRIPTION
\e will be added in the upcoming TOML 1.1; for the time being hide it behind an (unexported) tomlNext flag that's only set in tests.