### PR TITLE
Support times without seconds

### DIFF
--- a/internal/toml-test/version.go
+++ b/internal/toml-test/version.go
@@ -9,7 +9,11 @@ type versionSpec struct {
 }
 
 var versions = map[string]versionSpec{
-	"next": versionSpec{},
+	"next": versionSpec{
+		exclude: []string{
+			"invalid/datetime/no-secs", // Times without seconds is no longer invalid.
+		},
+	},
 
 	"1.0.0": versionSpec{
 		exclude: []string{

--- a/parse.go
+++ b/parse.go
@@ -333,11 +333,17 @@ func (p *parser) valueFloat(it item) (interface{}, tomlType) {
 var dtTypes = []struct {
 	fmt  string
 	zone *time.Location
+	next bool
 }{
-	{time.RFC3339Nano, time.Local},
-	{"2006-01-02T15:04:05.999999999", internal.LocalDatetime},
-	{"2006-01-02", internal.LocalDate},
-	{"15:04:05.999999999", internal.LocalTime},
+	{time.RFC3339Nano, time.Local, false},
+	{"2006-01-02T15:04:05.999999999", internal.LocalDatetime, false},
+	{"2006-01-02", internal.LocalDate, false},
+	{"15:04:05.999999999", internal.LocalTime, false},
+
+	// tomlNext
+	{"2006-01-02T15:04Z07:00", time.Local, true},
+	{"2006-01-02T15:04", internal.LocalDatetime, true},
+	{"15:04", internal.LocalTime, true},
 }
 
 func (p *parser) valueDatetime(it item) (interface{}, tomlType) {
@@ -348,6 +354,9 @@ func (p *parser) valueDatetime(it item) (interface{}, tomlType) {
 		err error
 	)
 	for _, dt := range dtTypes {
+		if dt.next && !tomlNext {
+			continue
+		}
 		t, err = time.ParseInLocation(dt.fmt, it.val, dt.zone)
 		if err == nil {
 			ok = true

--- a/toml_test.go
+++ b/toml_test.go
@@ -253,7 +253,9 @@ func TestTomlNext(t *testing.T) {
 
 // Make sure TOML 1.1 fails by default for now.
 func TestTomlNextFails(t *testing.T) {
-	runTomlTest(t, true, "valid/string/escape-esc")
+	runTomlTest(t, true,
+		"valid/string/escape-esc",
+		"valid/datetime/no-seconds")
 }
 
 func runTomlTest(t *testing.T, includeNext bool, wantFail ...string) {
@@ -317,9 +319,6 @@ func runTomlTest(t *testing.T, includeNext bool, wantFail ...string) {
 				"invalid/inline-table/add",
 				"invalid/table/duplicate-key-dotted-table",
 				"invalid/table/duplicate-key-dotted-table2",
-
-				// Upcoming TOML 1.1; not yet implemented
-				"valid/datetime/no-seconds",
 			},
 		}
 		if includeNext {


### PR DESCRIPTION
In TOML 1.1 seconds are optional; e.g. `13:37` or `2001-02-03 13:37` are valid.

Like other TOML 1.1 features this is hidden behind a flag, and only supported for the tests.