### PR TITLE
Allow newlines and trailing commas in inline tables

### DIFF
--- a/internal/toml-test/tests/valid/inline-table/newline.json
+++ b/internal/toml-test/tests/valid/inline-table/newline.json
@@ -1,0 +1,50 @@
+{
+  "tbl-1": {
+    "1": {
+      "type": "integer",
+      "value": "2"
+    },
+    "arr": [
+      {
+        "type": "integer",
+        "value": "1"
+      },
+      {
+        "type": "integer",
+        "value": "2"
+      },
+      {
+        "type": "integer",
+        "value": "3"
+      }
+    ],
+    "hello": {
+      "type": "string",
+      "value": "world"
+    },
+    "tbl": {
+      "k": {
+        "type": "integer",
+        "value": "1"
+      }
+    }
+  },
+  "tbl-2": {
+    "k": {
+      "type": "string",
+      "value": "\tHello\n\t"
+    }
+  },
+  "trailing-comma-1": {
+    "c": {
+      "type": "integer",
+      "value": "1"
+    }
+  },
+  "trailing-comma-2": {
+    "c": {
+      "type": "integer",
+      "value": "1"
+    }
+  }
+}

--- a/internal/toml-test/tests/valid/inline-table/newline.toml
+++ b/internal/toml-test/tests/valid/inline-table/newline.toml
@@ -1,0 +1,24 @@
+# TOML 1.1 supports newlines in inline tables and trailing commas.
+
+trailing-comma-1 = {
+	c = 1,
+}
+trailing-comma-2 = { c = 1, }
+
+tbl-1 = {
+	hello = "world",
+	1     = 2,
+	arr   = [1,
+	         2,
+	         3,
+	        ],
+	tbl = {
+		 k = 1,
+	}
+}
+
+tbl-2 = {
+	k = """
+	Hello
+	"""
+}

--- a/internal/toml-test/tests/valid/table/sub.json
+++ b/internal/toml-test/tests/valid/table/sub.json
@@ -1,0 +1,20 @@
+{
+  "a": {
+    "extend": {
+      "key": {
+        "type": "integer",
+        "value": "2"
+      },
+      "more": {
+        "key": {
+          "type": "integer",
+          "value": "3"
+        }
+      }
+    },
+    "key": {
+      "type": "integer",
+      "value": "1"
+    }
+  }
+}

--- a/internal/toml-test/tests/valid/table/sub.toml
+++ b/internal/toml-test/tests/valid/table/sub.toml
@@ -1,0 +1,9 @@
+[a]
+key = 1
+
+# a.extend is a key inside the "a" table.
+[a.extend]
+key = 2
+
+[a.extend.more]
+key = 3

--- a/internal/toml-test/version.go
+++ b/internal/toml-test/version.go
@@ -13,6 +13,11 @@ var versions = map[string]versionSpec{
 		exclude: []string{
 			"invalid/datetime/no-secs",          // Times without seconds is no longer invalid.
 			"invalid/string/basic-byte-escapes", // \x is now valid.
+			"invalid/inline-table/trailing-comma",
+			"invalid/inline-table/linebreak-1",
+			"invalid/inline-table/linebreak-2",
+			"invalid/inline-table/linebreak-3",
+			"invalid/inline-table/linebreak-4",
 		},
 	},
 
@@ -21,6 +26,7 @@ var versions = map[string]versionSpec{
 			"valid/string/escape-esc",                               // \e
 			"valid/string/hex-escape", "invalid/string/bad-hex-esc", // \x..
 			"valid/datetime/no-seconds", // Times without seconds
+			"valid/inline-table/newline",
 		},
 	},
 

--- a/lex.go
+++ b/lex.go
@@ -618,6 +618,9 @@ func lexInlineTableValue(lx *lexer) stateFn {
 	case isWhitespace(r):
 		return lexSkip(lx, lexInlineTableValue)
 	case isNL(r):
+		if tomlNext {
+			return lexSkip(lx, lexInlineTableValue)
+		}
 		return lx.errorPrevLine(errLexInlineTableNL{})
 	case r == '#':
 		lx.push(lexInlineTableValue)
@@ -640,6 +643,9 @@ func lexInlineTableValueEnd(lx *lexer) stateFn {
 	case isWhitespace(r):
 		return lexSkip(lx, lexInlineTableValueEnd)
 	case isNL(r):
+		if tomlNext {
+			return lexSkip(lx, lexInlineTableValueEnd)
+		}
 		return lx.errorPrevLine(errLexInlineTableNL{})
 	case r == '#':
 		lx.push(lexInlineTableValueEnd)
@@ -648,6 +654,9 @@ func lexInlineTableValueEnd(lx *lexer) stateFn {
 		lx.ignore()
 		lx.skip(isWhitespace)
 		if lx.peek() == '}' {
+			if tomlNext {
+				return lexInlineTableValueEnd
+			}
 			return lx.errorf("trailing comma not allowed in inline tables")
 		}
 		return lexInlineTableValue

--- a/toml_test.go
+++ b/toml_test.go
@@ -256,7 +256,8 @@ func TestTomlNextFails(t *testing.T) {
 	runTomlTest(t, true,
 		"valid/string/escape-esc",
 		"valid/datetime/no-seconds",
-		"valid/string/hex-escape")
+		"valid/string/hex-escape",
+		"valid/inline-table/newline")
 }
 
 func runTomlTest(t *testing.T, includeNext bool, wantFail ...string) {


### PR DESCRIPTION
Like other TOML 1.1 features this is hidden behind a flag, and only supported for the tests.