### PR TITLE
skip UTF-8 BOM also

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -66,6 +66,7 @@ func TestDecodeBOM(t *testing.T) {
 	for _, tt := range [][]byte{
 		[]byte("\xff\xfea = \"b\""),
 		[]byte("\xfe\xffa = \"b\""),
+		[]byte("\xef\xbb\xbfa = \"b\""),
 	} {
 		t.Run("", func(t *testing.T) {
 			var s struct{ A string }

--- a/parse.go
+++ b/parse.go
@@ -50,6 +50,8 @@ func parse(data string) (p *parser, err error) {
 	// which mangles stuff.
 	if strings.HasPrefix(data, "\xff\xfe") || strings.HasPrefix(data, "\xfe\xff") {
 		data = data[2:]
+	} else if strings.HasPrefix(data, "\xef\xbb\xbf") {
+		data = data[3:]
 	}
 
 	// Examine first few bytes for NULL bytes; this probably means it's a UTF-16

--- a/parse.go
+++ b/parse.go
@@ -47,10 +47,11 @@ func parse(data string) (p *parser, err error) {
 	}()
 
 	// Read over BOM; do this here as the lexer calls utf8.DecodeRuneInString()
-	// which mangles stuff.
-	if strings.HasPrefix(data, "\xff\xfe") || strings.HasPrefix(data, "\xfe\xff") {
+	// which mangles stuff. UTF-16 BOM isn't strictly valid, but some tools add
+	// it anyway.
+	if strings.HasPrefix(data, "\xff\xfe") || strings.HasPrefix(data, "\xfe\xff") { // UTF-16
 		data = data[2:]
-	} else if strings.HasPrefix(data, "\xef\xbb\xbf") {
+	} else if strings.HasPrefix(data, "\xef\xbb\xbf") { // UTF-8
 		data = data[3:]
 	}
 


### PR DESCRIPTION
I noticed that reading a UTF-8 encoded file with a BOM causes an error. Unfortunately, major Windows software adds a BOM to UTF-8 files.
UTF-16 support is fixed in #277 , but in addition, skipping the UTF-8 BOM (ef bb bf,  https://en.wikipedia.org/wiki/Byte_order_mark ) also solves the problem, I believe.

A sample is attached.

before:
```
OK(withoutBOM) あ
ERROR(withBOM) toml: line 1: expected '.' or '=', but got '\ufeff' instead
```

after:
```
OK(withoutBOM) あ
OK(withBOM) あ
```

[mini.zip](https://github.com/BurntSushi/toml/files/10527471/mini.zip)