### PR TITLE
Add Marshal Function

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -2,6 +2,7 @@ package toml
 
 import (
 	"bufio"
+	"bytes"
 	"encoding"
 	"encoding/json"
 	"errors"
@@ -74,6 +75,17 @@ var (
 // into valid TOML.
 type Marshaler interface {
 	MarshalTOML() ([]byte, error)
+}
+
+// Marshal returns a TOML representation of the Go value.
+//
+// See [Encoder] for a description of the encoding process.
+func Marshal(v any) ([]byte, error) {
+	buff := new(bytes.Buffer)
+	if err := NewEncoder(buff).Encode(v); err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
 }
 
 // Encoder encodes a Go to a TOML document.

--- a/encode_test.go
+++ b/encode_test.go
@@ -53,6 +53,13 @@ func TestEncodeRoundTrip(t *testing.T) {
 	if firstBuffer.String() != secondBuffer.String() {
 		t.Errorf("%s\n\nIS NOT IDENTICAL TO\n\n%s", firstBuffer.String(), secondBuffer.String())
 	}
+	out, err := Marshal(inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstBuffer.String() != string(out) {
+		t.Errorf("%s\n\nIS NOT IDENTICAL TO\n\n%s", firstBuffer.String(), string(out))
+	}
 }
 
 func TestEncodeArrayHashWithNormalHashOrder(t *testing.T) {


### PR DESCRIPTION
Added the Marshal function which returns the TOML representation of the Go value as bytes along with any error that may occur while marshaling. This adds parity with the existing Unmarshal function and conforms to the standard libraries JSON package, which also has both Unmarshal and Marshal.