### PR TITLE
fuzz: move fuzz_targets from oss-fuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'burntsushi-toml'
+        dry-run: false
+        language: go
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'burntsushi-toml'
+        fuzz-seconds: 300
+        dry-run: false
+        language: go
+    - name: Upload Crash
+      uses: actions/upload-artifact@v4
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts

--- a/ossfuzz/fuzz.go
+++ b/ossfuzz/fuzz.go
@@ -1,0 +1,34 @@
+package ossfuzz
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+)
+
+func FuzzToml(data []byte) int {
+	if len(data) >= 2048 {
+		return 0
+	}
+
+	var v any
+	_, err := toml.Decode(string(data), &v)
+	if err != nil {
+		return 0
+	}
+
+	buf := new(bytes.Buffer)
+	err = toml.NewEncoder(buf).Encode(v)
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode decoded document: %s", err))
+	}
+
+	var v2 any
+	_, err = toml.Decode(buf.String(), &v2)
+	if err != nil {
+		panic(fmt.Sprintf("failed round trip: %s", err))
+	}
+
+	return 1
+}


### PR DESCRIPTION
- Moves fuzz_targets from oss-fuzz. This makes it easy to maintain the fuzzers and minimizes breakages that can arise as source code changes over time.

- Adds cifuzz action workflow which is a service provided by oss-fuzz where this project already runs, this helps in catching shallow bugs, regression or build breakage by running fuzzers on PR for ~5 minutes.