### PR TITLE
fuzz: ignore roundtrip err till 1.23 lands

### DIFF
--- a/ossfuzz/fuzz.go
+++ b/ossfuzz/fuzz.go
@@ -3,6 +3,7 @@ package ossfuzz
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -27,6 +28,11 @@ func FuzzToml(data []byte) int {
 	var v2 any
 	_, err = toml.Decode(buf.String(), &v2)
 	if err != nil {
+		// TODO(manunio): remove this when 1.23 lands, see #407.
+		if strings.Contains(err.Error(), "invalid datetime") {
+			return 0
+		}
+
 		panic(fmt.Sprintf("failed round trip: %s", err))
 	}
 


### PR DESCRIPTION
This closes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68864, as fix has already been merged in go's: https://github.com/golang/go/commit/1849ce6a45640ec4a6e63138211eac4276473437 , I'll revert this as soon as 1.23 lands.