### PR TITLE
Fix metadata - do not reuse result of append

### DIFF
--- a/internal/toml-test/tests/valid/table/keyword-with-values.json
+++ b/internal/toml-test/tests/valid/table/keyword-with-values.json
@@ -1,0 +1,14 @@
+{
+    "false": {
+        "k": {"type": "integer", "value": "2"}
+    },
+    "inf": {
+        "k": {"type": "integer", "value": "3"}
+    },
+    "nan": {
+        "k": {"type": "integer", "value": "4"}
+    },
+    "true": {
+        "k": {"type": "integer", "value": "1"}
+    }
+}

--- a/internal/toml-test/tests/valid/table/keyword-with-values.toml
+++ b/internal/toml-test/tests/valid/table/keyword-with-values.toml
@@ -1,0 +1,11 @@
+[true]
+k = 1
+
+[false]
+k = 2
+
+[inf]
+k = 3
+
+[nan]
+k = 4

--- a/internal/toml-test/tests/valid/table/names-with-values.json
+++ b/internal/toml-test/tests/valid/table/names-with-values.json
@@ -1,0 +1,46 @@
+{
+    "a": {
+        " x ": {
+            "key": {"type": "integer", "value": "4"}
+        },
+        "b": {
+            "c": {
+                "key": {"type": "integer", "value": "1"}
+            }
+        },
+        "b.c": {
+            "key": {"type": "integer", "value": "2"}
+        },
+        "d.e": {
+            "key": {"type": "integer", "value": "3"}
+        }
+    },
+    "d": {
+        "e": {
+            "f": {
+                "key": {"type": "integer", "value": "5"}
+            }
+        }
+    },
+    "g": {
+        "h": {
+            "i": {
+                "key": {"type": "integer", "value": "6"}
+            }
+        }
+    },
+    "j": {
+        "ʞ": {
+            "l": {
+                "key": {"type": "integer", "value": "7"}
+            }
+        }
+    },
+    "x": {
+        "1": {
+            "2": {
+                "key": {"type": "integer", "value": "8"}
+            }
+        }
+    }
+}

--- a/internal/toml-test/tests/valid/table/names-with-values.toml
+++ b/internal/toml-test/tests/valid/table/names-with-values.toml
@@ -1,0 +1,23 @@
+[a.b.c]
+key = 1
+
+[a."b.c"]
+key = 2
+
+[a.'d.e']
+key = 3
+
+[a.' x ']
+key = 4
+
+[ d.e.f ]
+key = 5
+
+[ g . h . i ]
+key = 6
+
+[ j . "ʞ" . 'l' ]
+key = 7
+
+[x.1.2]
+key = 8

--- a/internal/toml-test/tests/valid/table/without-super-with-values.json
+++ b/internal/toml-test/tests/valid/table/without-super-with-values.json
@@ -1,0 +1,14 @@
+{
+    "x": {
+        "c": {"type": "integer", "value": "3"},
+        "d": {"type": "integer", "value": "4"},
+        "y": {
+            "z": {
+                "w": {
+                    "a": {"type": "integer", "value": "1"},
+                    "b": {"type": "integer", "value": "2"}
+                }
+            }
+        }
+    }
+}

--- a/internal/toml-test/tests/valid/table/without-super-with-values.toml
+++ b/internal/toml-test/tests/valid/table/without-super-with-values.toml
@@ -1,0 +1,9 @@
+# [x] you
+# [x.y] don't
+# [x.y.z] need these
+[x.y.z.w] # for this to work
+a = 1
+b = 2
+[x] # defining a super-table afterwards is ok
+c = 3
+d = 4

--- a/meta.go
+++ b/meta.go
@@ -135,9 +135,6 @@ func (k Key) maybeQuoted(i int) string {
 
 // Like append(), but only increase the cap by 1.
 func (k Key) add(piece string) Key {
-	if cap(k) > len(k) {
-		return append(k, piece)
-	}
 	newKey := make(Key, len(k)+1)
 	copy(newKey, k)
 	newKey[len(k)] = piece

--- a/toml_test.go
+++ b/toml_test.go
@@ -243,6 +243,14 @@ var metaTests = map[string]string{
 		x.y.z.w:  Hash
 		x:        Hash
 	`,
+	"table/without-super-with-values": `
+		x.y.z.w: Hash
+		x.y.z.w.a: Integer
+		x.y.z.w.b: Integer
+		x: Hash
+		x.c: Integer
+		x.d: Integer
+	`,
 }
 
 // TOML 1.0


### PR DESCRIPTION
[These lines](https://github.com/BurntSushi/toml/blob/eb727477b3f7e4aa878635d39257753f0840811b/meta.go#L138-L140) added in #400 caused the problem since the result of multiple `append` calls can return two slices backed by the same backing array. See demo here: https://go.dev/play/p/2FGKuCvCUKz. The bug only surfaces under specific conditions when the capacity of `parser.context` is increased by more than 1 due to [this append call](https://github.com/BurntSushi/toml/blob/eb727477b3f7e4aa878635d39257753f0840811b/parse.go#L606).

Fixes #417 