### PR TITLE
Return `[]any` for hash arrays when decoding to map / any.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -642,9 +642,9 @@ func (d *dish) UnmarshalTOML(p any) error {
 	data, _ := p.(map[string]any)
 	d.Name, _ = data["name"].(string)
 	d.Price, _ = data["price"].(float32)
-	ingredients, _ := data["ingredients"].([]map[string]any)
+	ingredients, _ := data["ingredients"].([]any)
 	for _, e := range ingredients {
-		n, _ := any(e).(map[string]any)
+		n, _ := e.(map[string]any)
 		name, _ := n["name"].(string)
 		i := ingredient{name}
 		d.Ingredients = append(d.Ingredients, i)

--- a/internal/tag/add.go
+++ b/internal/tag/add.go
@@ -27,12 +27,6 @@ func Add(key string, tomlData any) any {
 
 	// An array: we don't need to add any tags, just recurse for every table
 	// entry.
-	case []map[string]any:
-		typed := make([]map[string]any, len(orig))
-		for i, v := range orig {
-			typed[i] = Add("", v).(map[string]any)
-		}
-		return typed
 	case []any:
 		typed := make([]any, len(orig))
 		for i, v := range orig {

--- a/internal/toml-test/toml.go
+++ b/internal/toml-test/toml.go
@@ -38,12 +38,6 @@ func (r Test) CompareTOML(want, have any) Test {
 	switch w := want.(type) {
 	case map[string]any:
 		return r.cmpTOMLMap(w, have)
-	case []map[string]any:
-		ww := make([]any, 0, len(w))
-		for _, v := range w {
-			ww = append(ww, v)
-		}
-		return r.cmpTOMLArrays(ww, have)
 	case []any:
 		return r.cmpTOMLArrays(w, have)
 	default:
@@ -83,21 +77,10 @@ func (r Test) cmpTOMLMap(want map[string]any, have any) Test {
 }
 
 func (r Test) cmpTOMLArrays(want []any, have any) Test {
-	// Slice can be decoded to []any for an array of primitives, or
-	// []map[string]any for an array of tables.
-	//
-	// TODO: it would be nicer if it could always decode to []any?
 	haveSlice, ok := have.([]any)
-	if !ok {
-		tblArray, ok := have.([]map[string]any)
-		if !ok {
-			return r.mismatch("array", want, have)
-		}
 
-		haveSlice = make([]any, len(tblArray))
-		for i := range tblArray {
-			haveSlice[i] = tblArray[i]
-		}
+	if !ok {
+		return r.mismatch("array", want, have)
 	}
 
 	if len(want) != len(haveSlice) {
@@ -146,7 +129,7 @@ func deepEqual(want, have any) bool {
 
 func isTomlValue(v any) bool {
 	switch v.(type) {
-	case map[string]any, []map[string]any, []any:
+	case map[string]any, []any:
 		return false
 	}
 	return true


### PR DESCRIPTION
Currently they are returned in `[]map[string]any`, which makes the tree impractical to traverse.

Example: <https://github.com/itchyny/gojq/blob/0607aa5af33a4f980e3e769a1820db80e3cc7b23/encoder.go#L72> triggers the panic, instead of being encoded as an array.

Before my changes, the library depended on the peculiar behaviour of hash arrays and unfinished inline arrays being `[]map[string]any` while finished inline arrays became `[]any`. That was relevant for preventing finished inline arrays from being added to.

Since now everything is `[]any`, I added `locked` to the key info once the inline array (or any top-level field, really) is finished in order to be able to tell.

I'm not happy about the duplicate error lines, but am not sure it would be better to engineer something just for that.