### PR TITLE
Allow for setting TOML next.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1112,6 +1112,43 @@ func TestDecodeParallel(t *testing.T) {
 	wg.Wait()
 }
 
+func TestDecoderTomlNext(t *testing.T) {
+	os.Unsetenv("BURNTSUSHI_TOML_110")
+	dec := NewDecoder(nil)
+
+	if dec.IsTomlNext() {
+		t.Error("TOML next enabled by default, but shouldn't")
+	}
+
+	dec = NewDecoder(nil)
+	dec.SetTomlNext(true)
+
+	if !dec.IsTomlNext() {
+		t.Error("TOML next should have been enabled by SetTomlNext, but wasn't")
+	}
+
+	dec.SetTomlNext(false)
+
+	if dec.IsTomlNext() {
+		t.Error("TOML next should have been disabled by SetTomlNext, but wasn't")
+	}
+
+	WithTomlNext(func() {
+		dec = NewDecoder(nil)
+
+		if !dec.IsTomlNext() {
+			t.Error("TOML next should have been enabled by environment variable, but wasn't")
+		}
+
+		dec = NewDecoder(nil)
+		dec.SetTomlNext(false)
+
+		if dec.IsTomlNext() {
+			t.Error("TOML next should have been disabled by SetTomlNext environment variable, but wasn't")
+		}
+	})
+}
+
 // errorContains checks if the error message in have contains the text in
 // want.
 //

--- a/parse.go
+++ b/parse.go
@@ -3,7 +3,6 @@ package toml
 import (
 	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -31,9 +30,7 @@ type keyInfo struct {
 	tomlType tomlType
 }
 
-func parse(data string) (p *parser, err error) {
-	_, tomlNext := os.LookupEnv("BURNTSUSHI_TOML_110")
-
+func parse(data string, tomlNext bool) (p *parser, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if pErr, ok := r.(ParseError); ok {


### PR DESCRIPTION
Currently, the only way to enable TOML next (1.1.0) features is via the environment variable, which is very ugly if you want to do it in application code. Therefore I add the `SetTomlNext` method to the Decoder so it can be done more cleanly.