### PR TITLE
godocs.io isn't working

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ reflection interface similar to Go's standard library `json` and `xml` packages.
 
 Compatible with TOML version [v1.0.0](https://toml.io/en/v1.0.0).
 
-Documentation: https://godocs.io/github.com/BurntSushi/toml
+Documentation: https://pkg.go.dev/github.com/BurntSushi/toml
 
 See the [releases page](https://github.com/BurntSushi/toml/releases) for a
 changelog; this information is also in the git tag annotations (e.g. `git show


### PR DESCRIPTION
I don't know if this is just a temporary thing, but the existing docs link isn't working today :)