### PR TITLE
Fix ErrorWithPosition panic when less than two lines

### DIFF
--- a/error.go
+++ b/error.go
@@ -124,24 +124,17 @@ func (pe ParseError) ErrorWithPosition() string {
 	if pe.Position.Line > 2 {
 		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-2, expandTab(lines[pe.Position.Line-3]))
 	}
+	if pe.Position.Line > 1 {
+		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-1, expandTab(lines[pe.Position.Line-2]))
+	}
 
 	/// Expand tabs, so that the ^^^s are at the correct position, but leave
 	/// "column 10-13" intact. Adjusting this to the visual column would be
 	/// better, but we don't know the tabsize of the user in their editor, which
 	/// can be 8, 4, 2, or something else. We can't know. So leaving it as the
 	/// character index is probably the "most correct".
-	var (
-		expanded string
-		diff     int
-	)
-	if pe.Position.Line > 1 {
-		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-1, expandTab(lines[pe.Position.Line-2]))
-		expanded = expandTab(lines[pe.Position.Line-1])
-		diff = len(expanded) - len(lines[pe.Position.Line-1])
-	} else {
-		expanded = expandTab(lines[0])
-		diff = len(expanded) - len(lines[0])
-	}
+	expanded := expandTab(lines[pe.Position.Line-1])
+	diff := len(expanded) - len(lines[pe.Position.Line-1])
 
 	fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line, expanded)
 	fmt.Fprintf(b, "% 10s%s%s\n", "", strings.Repeat(" ", pe.Position.Col-1+diff), strings.Repeat("^", pe.Position.Len))

--- a/error.go
+++ b/error.go
@@ -124,17 +124,24 @@ func (pe ParseError) ErrorWithPosition() string {
 	if pe.Position.Line > 2 {
 		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-2, expandTab(lines[pe.Position.Line-3]))
 	}
-	if pe.Position.Line > 1 {
-		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-1, expandTab(lines[pe.Position.Line-2]))
-	}
 
 	/// Expand tabs, so that the ^^^s are at the correct position, but leave
 	/// "column 10-13" intact. Adjusting this to the visual column would be
 	/// better, but we don't know the tabsize of the user in their editor, which
 	/// can be 8, 4, 2, or something else. We can't know. So leaving it as the
 	/// character index is probably the "most correct".
-	expanded := expandTab(lines[pe.Position.Line-1])
-	diff := len(expanded) - len(lines[pe.Position.Line-1])
+	var (
+		expanded string
+		diff     int
+	)
+	if pe.Position.Line > 1 {
+		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-1, expandTab(lines[pe.Position.Line-2]))
+		expanded = expandTab(lines[pe.Position.Line-1])
+		diff = len(expanded) - len(lines[pe.Position.Line-1])
+	} else {
+		expanded = expandTab(lines[0])
+		diff = len(expanded) - len(lines[0])
+	}
 
 	fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line, expanded)
 	fmt.Fprintf(b, "% 10s%s%s\n", "", strings.Repeat(" ", pe.Position.Col-1+diff), strings.Repeat("^", pe.Position.Len))

--- a/error_test.go
+++ b/error_test.go
@@ -245,6 +245,19 @@ func TestParseError(t *testing.T) {
             |         15:04:05.856018510
 			`,
 		},
+
+		{
+			&struct{ String string }{},
+			`string = "test`,
+			`
+            | toml: error: unexpected EOF; expected '"'
+			|
+			| At line 0, column 14:
+			|
+			|       0 | string = "test
+			|                        ^
+			`,
+		},
 	}
 
 	prep := func(s string) string {

--- a/error_test.go
+++ b/error_test.go
@@ -252,9 +252,9 @@ func TestParseError(t *testing.T) {
 			`
             | toml: error: unexpected EOF; expected '"'
 			|
-			| At line 0, column 14:
+			| At line 1, column 14:
 			|
-			|       0 | string = "test
+			|       1 | string = "test
 			|                        ^
 			`,
 		},

--- a/lex.go
+++ b/lex.go
@@ -275,7 +275,9 @@ func (lx *lexer) errorPos(start, length int, err error) stateFn {
 func (lx *lexer) errorf(format string, values ...any) stateFn {
 	if lx.atEOF {
 		pos := lx.getPos()
-		pos.Line--
+		if lx.pos >= 1 && lx.input[lx.pos-1] == '\n' {
+			pos.Line--
+		}
 		pos.Len = 1
 		pos.Start = lx.pos - 1
 		lx.items <- item{typ: itemError, pos: pos, err: fmt.Errorf(format, values...)}


### PR DESCRIPTION
Currently, it is possible for `ParserError.ErrorWithPosition` to cause a panic for some input.
You can reproduce the panic using this example:

```go
v := &struct{ String string }{}
_, err := toml.Decode(`string = "test`, v)
parseErr := err.(toml.ParseError)
_ = parseErr.ErrorWithUsage()
``` 

I've added a fix and a new test case which covers this error.


