### PR TITLE
decode: mark nested fields as decoded as well

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -206,6 +206,13 @@ func markDecodedRecursive(md *MetaData, tmap map[string]any) {
 			markDecodedRecursive(md, tmap)
 			md.context = md.context[0 : len(md.context)-1]
 		}
+		if tarr, ok := tmap[key].([]map[string]any); ok {
+			for _, elm := range tarr {
+				md.context = append(md.context, key)
+				markDecodedRecursive(md, elm)
+				md.context = md.context[0 : len(md.context)-1]
+			}
+		}
 	}
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -1157,11 +1157,12 @@ func (cs *UnmarshalTOMLNoop) UnmarshalTOML(data any) error {
 
 func TestDecodeCustomStructMarkedDecoded(t *testing.T) {
 	var s struct {
-		Str UnmarshalTOMLNoop `toml:"str"`
-		Int UnmarshalTOMLNoop `toml:"int"`
-		Arr UnmarshalTOMLNoop `toml:"arr"`
-		Tbl UnmarshalTOMLNoop `toml:"tbl"`
-		Aot UnmarshalTOMLNoop `toml:"aot"`
+		Str    UnmarshalTOMLNoop `toml:"str"`
+		Int    UnmarshalTOMLNoop `toml:"int"`
+		Arr    UnmarshalTOMLNoop `toml:"arr"`
+		Tbl    UnmarshalTOMLNoop `toml:"tbl"`
+		Aot    UnmarshalTOMLNoop `toml:"aot"`
+		Nested UnmarshalTOMLNoop `toml:"nested"`
 	}
 	meta, err := Decode(`
 		str = "bar"
@@ -1176,6 +1177,11 @@ func TestDecodeCustomStructMarkedDecoded(t *testing.T) {
 		a = 1
 		[[aot]]
 		a = 1
+
+		[[nested.a]]
+		e = 5
+		[[nested.a]]
+		f = 6
 	`, &s)
 	if err != nil {
 		t.Fatalf("Decode failed: %s", err)


### PR DESCRIPTION
This commit is a small followup for PR#426 to handle another case with the custom unmarshal. This was found in a complex TOML based image customization "blueprint", c.f. https://github.com/osbuild/blueprint/pull/12

With this commit the test in the other PR passes but I also extracted a minimal testcase (the naming may need tweaking, I'm not super familar with the naming convention inside "toml")