### PR TITLE
Ensure constant format strings in wf calls

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -228,9 +228,9 @@ func (enc *Encoder) eElement(rv reflect.Value) {
 		}
 		switch v.Location() {
 		default:
-			enc.wf(v.Format(format))
+			enc.write(v.Format(format))
 		case internal.LocalDatetime, internal.LocalDate, internal.LocalTime:
-			enc.wf(v.In(time.UTC).Format(format))
+			enc.write(v.In(time.UTC).Format(format))
 		}
 		return
 	case Marshaler:
@@ -279,40 +279,40 @@ func (enc *Encoder) eElement(rv reflect.Value) {
 	case reflect.String:
 		enc.writeQuoted(rv.String())
 	case reflect.Bool:
-		enc.wf(strconv.FormatBool(rv.Bool()))
+		enc.write(strconv.FormatBool(rv.Bool()))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		enc.wf(strconv.FormatInt(rv.Int(), 10))
+		enc.write(strconv.FormatInt(rv.Int(), 10))
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		enc.wf(strconv.FormatUint(rv.Uint(), 10))
+		enc.write(strconv.FormatUint(rv.Uint(), 10))
 	case reflect.Float32:
 		f := rv.Float()
 		if math.IsNaN(f) {
 			if math.Signbit(f) {
-				enc.wf("-")
+				enc.write("-")
 			}
-			enc.wf("nan")
+			enc.write("nan")
 		} else if math.IsInf(f, 0) {
 			if math.Signbit(f) {
-				enc.wf("-")
+				enc.write("-")
 			}
-			enc.wf("inf")
+			enc.write("inf")
 		} else {
-			enc.wf(floatAddDecimal(strconv.FormatFloat(f, 'g', -1, 32)))
+			enc.write(floatAddDecimal(strconv.FormatFloat(f, 'g', -1, 32)))
 		}
 	case reflect.Float64:
 		f := rv.Float()
 		if math.IsNaN(f) {
 			if math.Signbit(f) {
-				enc.wf("-")
+				enc.write("-")
 			}
-			enc.wf("nan")
+			enc.write("nan")
 		} else if math.IsInf(f, 0) {
 			if math.Signbit(f) {
-				enc.wf("-")
+				enc.write("-")
 			}
-			enc.wf("inf")
+			enc.write("inf")
 		} else {
-			enc.wf(floatAddDecimal(strconv.FormatFloat(f, 'g', -1, 64)))
+			enc.write(floatAddDecimal(strconv.FormatFloat(f, 'g', -1, 64)))
 		}
 	case reflect.Array, reflect.Slice:
 		enc.eArrayOrSliceElement(rv)
@@ -342,20 +342,20 @@ func floatAddDecimal(fstr string) string {
 }
 
 func (enc *Encoder) writeQuoted(s string) {
-	enc.wf("\"%s\"", dblQuotedReplacer.Replace(s))
+	enc.writef("\"%s\"", dblQuotedReplacer.Replace(s))
 }
 
 func (enc *Encoder) eArrayOrSliceElement(rv reflect.Value) {
 	length := rv.Len()
-	enc.wf("[")
+	enc.write("[")
 	for i := 0; i < length; i++ {
 		elem := eindirect(rv.Index(i))
 		enc.eElement(elem)
 		if i != length-1 {
-			enc.wf(", ")
+			enc.write(", ")
 		}
 	}
-	enc.wf("]")
+	enc.write("]")
 }
 
 func (enc *Encoder) eArrayOfTables(key Key, rv reflect.Value) {
@@ -368,7 +368,7 @@ func (enc *Encoder) eArrayOfTables(key Key, rv reflect.Value) {
 			continue
 		}
 		enc.newline()
-		enc.wf("%s[[%s]]", enc.indentStr(key), key)
+		enc.writef("%s[[%s]]", enc.indentStr(key), key)
 		enc.newline()
 		enc.eMapOrStruct(key, trv, false)
 	}
@@ -381,7 +381,7 @@ func (enc *Encoder) eTable(key Key, rv reflect.Value) {
 		enc.newline()
 	}
 	if len(key) > 0 {
-		enc.wf("%s[%s]", enc.indentStr(key), key)
+		enc.writef("%s[%s]", enc.indentStr(key), key)
 		enc.newline()
 	}
 	enc.eMapOrStruct(key, rv, false)
@@ -427,7 +427,7 @@ func (enc *Encoder) eMap(key Key, rv reflect.Value, inline bool) {
 			if inline {
 				enc.writeKeyValue(Key{mapKey.String()}, val, true)
 				if trailC || i != len(mapKeys)-1 {
-					enc.wf(", ")
+					enc.write(", ")
 				}
 			} else {
 				enc.encode(key.add(mapKey.String()), val)
@@ -436,12 +436,12 @@ func (enc *Encoder) eMap(key Key, rv reflect.Value, inline bool) {
 	}
 
 	if inline {
-		enc.wf("{")
+		enc.write("{")
 	}
 	writeMapKeys(mapKeysDirect, len(mapKeysSub) > 0)
 	writeMapKeys(mapKeysSub, false)
 	if inline {
-		enc.wf("}")
+		enc.write("}")
 	}
 }
 
@@ -539,7 +539,7 @@ func (enc *Encoder) eStruct(key Key, rv reflect.Value, inline bool) {
 			if inline {
 				enc.writeKeyValue(Key{keyName}, fieldVal, true)
 				if fieldIndex[0] != totalFields-1 {
-					enc.wf(", ")
+					enc.write(", ")
 				}
 			} else {
 				enc.encode(key.add(keyName), fieldVal)
@@ -548,14 +548,14 @@ func (enc *Encoder) eStruct(key Key, rv reflect.Value, inline bool) {
 	}
 
 	if inline {
-		enc.wf("{")
+		enc.write("{")
 	}
 
 	l := len(fieldsDirect) + len(fieldsSub)
 	writeFields(fieldsDirect, l)
 	writeFields(fieldsSub, l)
 	if inline {
-		enc.wf("}")
+		enc.write("}")
 	}
 }
 
@@ -705,7 +705,7 @@ func isEmpty(rv reflect.Value) bool {
 
 func (enc *Encoder) newline() {
 	if enc.hasWritten {
-		enc.wf("\n")
+		enc.write("\n")
 	}
 }
 
@@ -727,19 +727,26 @@ func (enc *Encoder) writeKeyValue(key Key, val reflect.Value, inline bool) {
 		enc.eElement(val)
 		return
 	}
-	enc.wf("%s%s = ", enc.indentStr(key), key.maybeQuoted(len(key)-1))
+	enc.writef("%s%s = ", enc.indentStr(key), key.maybeQuoted(len(key)-1))
 	enc.eElement(val)
 	if !inline {
 		enc.newline()
 	}
 }
 
-func (enc *Encoder) wf(format string, v ...any) {
-	_, err := fmt.Fprintf(enc.w, format, v...)
+func (enc *Encoder) writec(_ int, err error) {
 	if err != nil {
 		encPanic(err)
 	}
 	enc.hasWritten = true
+}
+
+func (enc *Encoder) write(v ...any) {
+	enc.writec(fmt.Fprint(enc.w, v...))
+}
+
+func (enc *Encoder) writef(format string, v ...any) {
+	enc.writec(fmt.Fprintf(enc.w, format, v...))
 }
 
 func (enc *Encoder) indentStr(key Key) string {


### PR DESCRIPTION
Go 1.24's `vet` tool has improved its `printf` analyzer. It now reports a diagnostic for calls like `fmt.Printf(s)` where `s` is a non-constant format string, and no additional arguments are provided. This change ensures that potential misuse of dynamic format strings is caught, preventing unexpected behavior or errors caused by unintended format specifiers.

```
$ GO111MODULE=off go vet ./...
# github.com/BurntSushi/toml/internal/toml-test
internal/toml-test/runner.go:393:17: non-constant format string in call to (github.com/BurntSushi/toml/internal/toml-test.Test).fail
internal/toml-test/runner.go:420:17: non-constant format string in call to (github.com/BurntSushi/toml/internal/toml-test.Test).fail
internal/toml-test/runner.go:423:17: non-constant format string in call to (github.com/BurntSushi/toml/internal/toml-test.Test).fail
internal/toml-test/runner.go:449:17: non-constant format string in call to (github.com/BurntSushi/toml/internal/toml-test.Test).fail
# github.com/BurntSushi/toml
# [github.com/BurntSushi/toml]
./encode.go:231:11: non-constant format string in call to (*github.com/BurntSushi/toml.Encoder).wf
./encode.go:233:11: non-constant format string in call to (*github.com/BurntSushi/toml.Encoder).wf
./encode.go:282:10: non-constant format string in call to (*github.com/BurntSushi/toml.Encoder).wf
./encode.go:284:10: non-constant format string in call to (*github.com/BurntSushi/toml.Encoder).wf
./encode.go:286:10: non-constant format string in call to (*github.com/BurntSushi/toml.Encoder).wf
./encode.go:300:11: non-constant format string in call to (*github.com/BurntSushi/toml.Encoder).wf
./encode.go:315:11: non-constant format string in call to (*github.com/BurntSushi/toml.Encoder).wf
```

This PR fixes the occurrences, where non-constant format strings were used in calls to `wf()` function, to satisfy `vet` in modern Go versions, and is compatible with older versions.