### PR TITLE
New EncodeFile method with a test

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -135,6 +136,20 @@ type Encoder struct {
 // NewEncoder create a new Encoder.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{w: bufio.NewWriter(w), Indent: "  "}
+}
+
+// EncodeFile encodes and writes data to a file using [*Encoder.Encode]
+func EncodeFile(path string, v any) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	err = NewEncoder(file).Encode(v)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Encode writes a TOML representation of the Go value to the [Encoder]'s writer.


### PR DESCRIPTION
## What is added: 
This adds a `EncodeFile` method similar to the `DecodeFile` method. Instead of reading a file, it writes to one and returns an error if anything goes wrong. 

**Use case:**
This function should make it easier to for example save your config data to your `config.toml` file without writing your own function.