### PR TITLE
docs: fix UnmarshalTOML wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ func decode() {
 }
 ```
 
-To target TOML specifically you can implement `UnmarshalTOML` TOML interface in
+To target TOML specifically you can implement the `UnmarshalTOML` interface in
 a similar way.
 
 ### More complex usage


### PR DESCRIPTION
## Summary
- Fix wording in the README sentence describing the `UnmarshalTOML` interface.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/BurntSushi/toml/blob/master/README.md

## Validation/testing
- Not run (docs change only)