### PR TITLE
docs: fix typo in runner comment

### DIFF
--- a/internal/toml-test/runner.go
+++ b/internal/toml-test/runner.go
@@ -101,7 +101,7 @@ type Test struct {
 
 	Skipped          bool          // Skipped this test?
 	Failure          string        // Failure message.
-	Key              string        // TOML key the failure occured on; may be blank.
+	Key              string        // TOML key the failure occurred on; may be blank.
 	Encoder          bool          // Encoder test?
 	Input            string        // The test case that we sent to the external program.
 	Output           string        // Output from the external program.


### PR DESCRIPTION
## Summary
- fix a typo in the internal TOML test runner comment.

## Related issue
- N/A; trivial docs/comment fix.

## Guideline alignment
- No CONTRIBUTING or PR template was present; kept this to a single comment-only change.

## Validation
- Not run; docs/comment-only change.
