### PR TITLE
docs: fix occurred wording in test runner comment

### DIFF
--- a/internal/toml-test/runner.go
+++ b/internal/toml-test/runner.go
@@ -101,7 +101,7 @@ type Test struct {
 
 	Skipped          bool          // Skipped this test?
 	Failure          string        // Failure message.
-	Key              string        // TOML key the failure occured on; may be blank.
+	Key              string        // TOML key the failure occurred on; may be blank.
 	Encoder          bool          // Encoder test?
 	Input            string        // The test case that we sent to the external program.
 	Output           string        // Output from the external program.


### PR DESCRIPTION
## Summary
- fix `occured` -> `occurred` in the TOML test runner comment

## Related issue
- N/A (trivial comment fix)

## Guideline alignment
- No `CONTRIBUTING` guide or PR template was found in this repository. This PR keeps the change to one focused, comment-only file with no behavior change.

## Validation/testing note
- Not run (comment-only change)
