### PR TITLE
fix: reject scalar values redefining implicit tables

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -236,6 +236,29 @@ func TestDecodeErrors(t *testing.T) {
 	}
 }
 
+// Regression test for https://github.com/BurntSushi/toml/issues/451
+// Redefining a dotted-key parent as a scalar must be rejected even when
+// only a single sub-key was defined.
+func TestDecodeScalarRedefinesImplicitTable(t *testing.T) {
+	tests := []struct {
+		name string
+		toml string
+	}{
+		{"single sub-key", "a.b = 1\na = 7"},
+		{"two sub-keys", "a.b = 1\na.c = 2\na = 7"},
+		{"scalar then dotted", "a = 7\na.b = 1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var v any
+			_, err := Decode(tt.toml, &v)
+			if err == nil {
+				t.Fatalf("expected error for:\n%s", tt.toml)
+			}
+		})
+	}
+}
+
 func TestDecodeIgnoreFields(t *testing.T) {
 	const input = `
 Number = 123

--- a/parse.go
+++ b/parse.go
@@ -643,6 +643,11 @@ func (p *parser) setValue(key string, value any) {
 			return
 		}
 		if p.isImplicit(keyContext) {
+			// Only allow implicit → explicit promotion for tables.
+			// A scalar value must not silently replace an implicitly created table.
+			if _, isHash := value.(map[string]any); !isHash {
+				p.panicf("Key '%s' has already been defined.", keyContext)
+			}
 			p.removeImplicit(keyContext)
 			return
 		}


### PR DESCRIPTION
Fixes #451

When a dotted key like `a.b = 1` implicitly creates table `a`, a subsequent `a = 7` was silently accepted (the scalar was discarded). With two sub-keys the error was correctly raised, but with a single sub-key the implicit flag was never cleared, so `setValue` allowed the redefinition.

**Before:** `a.b = 1` then `a = 7` → no error, scalar silently dropped
**After:** `a.b = 1` then `a = 7` → `Key 'a' has already been defined.`

The fix adds a type check in `setValue`: only `map[string]any` values (tables) may promote an implicit key. Scalar values now hit the existing "already defined" error path.

**Validation:** `go test ./...` and `go vet ./...` pass. Regression test added covering both the single-subkey and two-subkey cases.