### PR TITLE
fix: parsing TOML tags with commas in key names, add regression tests

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1064,6 +1064,20 @@ func TestDecodeDoubleTags(t *testing.T) {
 	}
 }
 
+func TestDecodeTagNameWithComma(t *testing.T) {
+	var s struct {
+		Value string `toml:"stack(x,n)"`
+	}
+	_, err := Decode(`"stack(x,n)" = "foobar"`, &s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Value != "foobar" {
+		t.Errorf("\nhave: %s\nwant: %s\n", s.Value, "foobar")
+	}
+}
+
 func TestMetaKeys(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/encode.go
+++ b/encode.go
@@ -650,16 +650,29 @@ func getOptions(tag reflect.StructTag) tagOptions {
 		return tagOptions{skip: true}
 	}
 	var opts tagOptions
-	parts := strings.Split(t, ",")
-	opts.name = parts[0]
-	for _, s := range parts[1:] {
+	for {
+		i := strings.LastIndexByte(t, ',')
+		if i < 0 {
+			break
+		}
+
+		s := t[i+1:]
 		switch s {
 		case "omitempty":
 			opts.omitempty = true
+			t = t[:i]
 		case "omitzero":
 			opts.omitzero = true
+			t = t[:i]
+		default:
+			// Unknown suffix: treat the full tag value as the key name.
+			i = -1
+		}
+		if i < 0 {
+			break
 		}
 	}
+	opts.name = t
 	return opts
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -1287,6 +1287,22 @@ c = 3
 	}
 }
 
+func TestEncodeTagNameWithComma(t *testing.T) {
+	v := struct {
+		S string `toml:"stack(x,n)"`
+	}{S: "foobar"}
+
+	encodeExpected(t, "tag name with comma", v, `"stack(x,n)" = "foobar"`, nil)
+}
+
+func TestEncodeTagNameWithCommaAndOptions(t *testing.T) {
+	v := struct {
+		S string `toml:"stack(x,n),omitempty"`
+	}{S: "foobar"}
+
+	encodeExpected(t, "tag name with comma and omitempty", v, `"stack(x,n)" = "foobar"`, nil)
+}
+
 type (
 	Doc1 struct{ N string }
 	Doc2 struct{ N string }


### PR DESCRIPTION
Hello,

This PR fix struct tag parsing so TOML key names containing commas are preserved during encode and decode.

This addresses cases like `stack(x,n)`, which were previously truncated at the comma (see https://github.com/sclevine/yj/issues/52)

The tag parser split on every comma and treated the first segment as the key name.

Example behavior before this change:
- Tag value: `stack(x,n),omitempty`
- Parsed key name: `stack(x`
- Result: incorrect key lookup/output

Before this PR, tag parsing used a global comma split, which cannot distinguish:
- commas that are part of the key name
- commas that introduce options such as `omitempty` and/or `omitzero`

With this PR, tag parsing has been updated:
- parse known options from the right side only
- keep the remaining left side as the full key name
- preserve unknown suffixes as part of the key name instead of truncating

This keeps existing option behavior while correctly handling commas in key names.

I also added regression tests for both encode and decode.