### PR TITLE
errors: implement Unwrap for ParseError

### DIFF
--- a/error.go
+++ b/error.go
@@ -98,6 +98,10 @@ func (pe ParseError) Error() string {
 	return fmt.Sprintf("toml: line %d (last key %q): %s", pe.Position.Line, pe.LastKey, pe.Message)
 }
 
+func (pe ParseError) Unwrap() error {
+	return pe.err
+}
+
 // ErrorWithPosition returns the error with detailed location context.
 //
 // See the documentation on [ParseError].

--- a/error_test.go
+++ b/error_test.go
@@ -301,6 +301,8 @@ func TestParseError(t *testing.T) {
 	}
 }
 
+var errInvalidValue = errors.New("invalid value")
+
 type Enum1 uint8
 
 func (n *Enum1) UnmarshalText(text []byte) error {
@@ -308,7 +310,7 @@ func (n *Enum1) UnmarshalText(text []byte) error {
 	case "ok":
 		*n = 1
 	default:
-		return fmt.Errorf("invalid value: %q", t)
+		return fmt.Errorf("%w: %q", errInvalidValue, t)
 	}
 	return nil
 }
@@ -323,6 +325,9 @@ func TestUnmarshalTypeError(t *testing.T) {
 	_, err := toml.Decode("k1 = 'asd'\nk2 = 'ok'\nk3 = 'invalid'\nk4 = 'ok'", &c)
 	if err == nil {
 		t.Fatal("error is nil")
+	}
+	if !errors.Is(err, errInvalidValue) {
+		t.Errorf("error %#v does not wrap errInvalidValue (%v)", err, errInvalidValue)
 	}
 	var pErr toml.ParseError
 	if !errors.As(err, &pErr) {
@@ -351,7 +356,7 @@ func (n *Enum2) UnmarshalTOML(text any) error {
 	case "ok":
 		*n = 1
 	default:
-		return fmt.Errorf("invalid value: %q", t)
+		return fmt.Errorf("%w: %q", errInvalidValue, t)
 	}
 	return nil
 }
@@ -365,6 +370,9 @@ func TestMarshalError(t *testing.T) {
 	_, err := toml.Decode("k1 = 'asd'\nk2 = 'ok'\nk3 = 'invalid'\nk4 = 'ok'", &c)
 	if err == nil {
 		t.Fatal("error is nil")
+	}
+	if !errors.Is(err, errInvalidValue) {
+		t.Errorf("error %#v does not wrap errInvalidValue (%v)", err, errInvalidValue)
 	}
 	var pErr toml.ParseError
 	if !errors.As(err, &pErr) {


### PR DESCRIPTION
For types with custom UnmarshalTOML methods, being able to return an
error that is then checked using errors.Is() is quite handy and matches
user expecations with regards to how error wrapping works in modern Go.

Signed-off-by: Aleksa Sarai <aleksa@amutable.com>