### PR TITLE
fix: reject scalar values redefining implicit tables from dotted keys

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -249,6 +249,8 @@ func TestDecodeErrors(t *testing.T) {
 			fmt.Sprintf(`value = %d`, math.MaxUint32+int64(1)),
 			map[int]string{32: `toml: line 1 (last key "value"): 4294967296 is out of range for uint`}[strconv.IntSize],
 		},
+		// Regression test for #451: scalar redefining implicit table from dotted key.
+		{new(map[string]any), "a.b = 1\na = 7", `toml: line 2 (last key "a"): Key 'a' has already been defined.`},
 	}
 
 	for _, tt := range tests {

--- a/parse.go
+++ b/parse.go
@@ -654,6 +654,11 @@ func (p *parser) setValue(key string, value any) {
 			return
 		}
 		if p.isImplicit(keyContext) {
+			// Only allow implicit->explicit promotion for tables.
+			// A scalar must not silently replace an implicit table.
+			if _, isHash := value.(map[string]any); !isHash {
+				p.panicf("Key '%s' has already been defined.", keyContext)
+			}
 			p.removeImplicit(keyContext)
 			return
 		}

--- a/toml_test.go
+++ b/toml_test.go
@@ -336,7 +336,6 @@ func TestToml(t *testing.T) {
 			"invalid/table/append-with-dotted-keys-01",
 			"invalid/table/append-with-dotted-keys-02",
 			"invalid/table/append-with-dotted-keys-03",
-			"invalid/table/append-with-dotted-keys-05",
 			"invalid/table/append-with-dotted-keys-08",
 			"invalid/table/duplicate-key-04",
 			"invalid/table/duplicate-key-05",


### PR DESCRIPTION
## Summary

Fixes #451

When a dotted key like  implicitly creates table , a subsequent scalar assignment  should be rejected since  is already defined as a table, not silently accepted.

The fix adds a type check in  when allowing implicit-to-explicit promotion: only  (tables) are accepted. Scalars and arrays are rejected with the existing "Key has already been defined" error.

## Test plan

- [x] Added regression test in  for the  case
- [x] Verified  still works ( — table redefines implicit table)
- [x] Verified table redefines implicit table via  header still works ()
- [x] All existing tests pass ()
- [x]  clean