### PR TITLE
fix: error on case-insensitive duplicate struct keys

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -302,6 +302,20 @@ func (md *MetaData) unify(data any, rv reflect.Value) error {
 	return md.e("unsupported type %s", rv.Kind())
 }
 
+func fieldIndexKey(index []int) string {
+	if len(index) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, n := range index {
+		if i > 0 {
+			b.WriteByte('.')
+		}
+		b.WriteString(strconv.Itoa(n))
+	}
+	return b.String()
+}
+
 func (md *MetaData) unifyStruct(mapping any, rv reflect.Value) error {
 	tmap, ok := mapping.(map[string]any)
 	if !ok {
@@ -311,6 +325,7 @@ func (md *MetaData) unifyStruct(mapping any, rv reflect.Value) error {
 		return md.e("type mismatch for %s: expected table but found %s", rv.Type().String(), fmtType(mapping))
 	}
 
+	assigned := make(map[string]string)
 	for key, datum := range tmap {
 		var f *field
 		fields := cachedTypeFields(rv.Type())
@@ -325,6 +340,12 @@ func (md *MetaData) unifyStruct(mapping any, rv reflect.Value) error {
 			}
 		}
 		if f != nil {
+			fieldKey := fieldIndexKey(f.index)
+			if prev, ok := assigned[fieldKey]; ok {
+				return md.e("keys %q and %q both map to the field %q", prev, key, f.name)
+			}
+			assigned[fieldKey] = key
+
 			subv := rv
 			for _, i := range f.index {
 				subv = indirect(subv.Field(i))

--- a/decode_test.go
+++ b/decode_test.go
@@ -333,6 +333,23 @@ func TestDecodeIntOverflow(t *testing.T) {
 	}
 }
 
+func TestDecodeCaseInsensitiveDuplicateKeys(t *testing.T) {
+	type cfg struct {
+		Fish string `toml:"fish"`
+	}
+	var conf cfg
+	_, err := Decode(`
+fish = "Cod"
+Fish = "Shark"
+`, &conf)
+	if err == nil {
+		t.Fatal("expected error for case-insensitive duplicate keys")
+	}
+	if !strings.Contains(err.Error(), `keys "fish" and "Fish"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDecodeFloatOverflow(t *testing.T) {
 	tests := []struct {
 		value    string


### PR DESCRIPTION
## Summary

- Track struct fields assigned during decode and return an error when two distinct TOML keys map to the same field (exact or case-insensitive match).
- Fixes non-deterministic overwrites such as `fish` and `Fish` both targeting `toml:"fish"`.

Fixes #449

## Test plan

- [x] `go test -run TestDecodeCaseInsensitiveDuplicateKeys`
- [x] `go test ./...`