### PR TITLE
Support decoding hex into []byte and [N]byte

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -275,6 +275,13 @@ func (md *MetaData) unify(data any, rv reflect.Value) error {
 
 	k := rv.Kind()
 
+	if (k == reflect.Slice || k == reflect.Array) && rv.Type().Elem().Kind() == reflect.Uint8 {
+		if k == reflect.Slice {
+			return md.unifyBytes(data, rv)
+		}
+		return md.unifyBytesArray(data, rv)
+	}
+
 	if k >= reflect.Int && k <= reflect.Uint64 {
 		return md.unifyInt(data, rv)
 	}
@@ -420,6 +427,60 @@ func (md *MetaData) unifySlice(data any, rv reflect.Value) error {
 	return md.unifySliceArray(datav, rv)
 }
 
+
+
+func (md *MetaData) unifyBytes(data any, rv reflect.Value) error {
+	b, err := md.byteSliceFromData(data)
+	if err != nil {
+		return err
+	}
+	if !rv.IsNil() && rv.Len() != len(b) {
+		rv.Set(reflect.MakeSlice(rv.Type(), len(b), len(b)))
+	} else if rv.IsNil() || rv.Cap() < len(b) {
+		rv.Set(reflect.MakeSlice(rv.Type(), len(b), len(b)))
+	} else {
+		rv.SetLen(len(b))
+	}
+	reflect.Copy(rv, reflect.ValueOf(b))
+	return nil
+}
+
+func (md *MetaData) unifyBytesArray(data any, rv reflect.Value) error {
+	b, err := md.byteSliceFromData(data)
+	if err != nil {
+		return err
+	}
+	if len(b) != rv.Len() {
+		return md.e("expected array length %d; got %d bytes", rv.Len(), len(b))
+	}
+	reflect.Copy(rv, reflect.ValueOf(b))
+	return nil
+}
+
+func (md *MetaData) byteSliceFromData(data any) ([]byte, error) {
+	switch v := data.(type) {
+	case []byte:
+		out := make([]byte, len(v))
+		copy(out, v)
+		return out, nil
+	case string:
+		return decodeHexBytes(v)
+	case int64:
+		if v < 0 {
+			return nil, md.badtype("[]byte", data)
+		}
+		if v == 0 {
+			return []byte{}, nil
+		}
+		s := strconv.FormatInt(v, 16)
+		if len(s)%2 != 0 {
+			s = "0" + s
+		}
+		return decodeHexBytes(s)
+	default:
+		return nil, md.badtype("[]byte", data)
+	}
+}
 func (md *MetaData) unifySliceArray(data, rv reflect.Value) error {
 	l := data.Len()
 	for i := 0; i < l; i++ {

--- a/decode_test.go
+++ b/decode_test.go
@@ -1223,3 +1223,62 @@ func TestMaxTableNesting(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeHexBytes(t *testing.T) {
+	hash := "6501bc346e2ad6eecae3bcf7eee78ac21b1a03bdc4fda879a4d24793c1f08db7"
+	want, err := decodeHexBytes(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("0x literal", func(t *testing.T) {
+		var s struct {
+			X []byte `toml:"x"`
+		}
+		if _, err := Decode(`x = 0x`+hash, &s); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(s.X, want) {
+			t.Fatalf("got %x, want %x", s.X, want)
+		}
+	})
+
+	t.Run("hex string", func(t *testing.T) {
+		var s struct {
+			X []byte `toml:"x"`
+		}
+		if _, err := Decode(`x = "`+hash+`"`, &s); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(s.X, want) {
+			t.Fatalf("got %x, want %x", s.X, want)
+		}
+	})
+
+	t.Run("fixed array", func(t *testing.T) {
+		var s struct {
+			X [32]byte `toml:"x"`
+		}
+		if _, err := Decode(`x = 0x`+hash, &s); err != nil {
+			t.Fatal(err)
+		}
+		var expect [32]byte
+		copy(expect[:], want)
+		if s.X != expect {
+			t.Fatalf("got %x, want %x", s.X, want)
+		}
+	})
+
+	t.Run("small int literal", func(t *testing.T) {
+		var s struct {
+			X []byte `toml:"x"`
+		}
+		if _, err := Decode(`x = 0xff`, &s); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(s.X, []byte{0xff}) {
+			t.Fatalf("got %x, want ff", s.X)
+		}
+	})
+}
+

--- a/hexbytes.go
+++ b/hexbytes.go
@@ -1,0 +1,42 @@
+package toml
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// decodeHexBytes decodes a hexadecimal string into bytes. An optional "0x" or
+// "0X" prefix is stripped. The string must contain an even number of hex digits.
+func decodeHexBytes(s string) ([]byte, error) {
+	s = strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
+	if len(s) == 0 {
+		return nil, nil
+	}
+	if len(s)%2 != 0 {
+		return nil, fmt.Errorf("toml: odd number of hex digits in %q", s)
+	}
+	for _, r := range s {
+		if !isHex(r) {
+			return nil, fmt.Errorf("toml: invalid hex digit in %q", s)
+		}
+	}
+	return hex.DecodeString(s)
+}
+
+// tryParseOversizedHexInteger parses a 0x-prefixed integer literal that does
+// not fit in int64 as a byte slice instead.
+func tryParseOversizedHexInteger(val string) ([]byte, bool) {
+	lower := strings.ToLower(val)
+	if !strings.HasPrefix(lower, "0x") {
+		return nil, false
+	}
+	if len(lower) <= 2+16 {
+		return nil, false
+	}
+	b, err := decodeHexBytes(val)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}

--- a/hexbytes_test.go
+++ b/hexbytes_test.go
@@ -1,0 +1,53 @@
+package toml
+
+import "testing"
+
+func TestParseOversizedHexLiteral(t *testing.T) {
+	hash := "6501bc346e2ad6eecae3bcf7eee78ac21b1a03bdc4fda879a4d24793c1f08db7"
+	p, err := parse("x = 0x"+hash, 128)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, ok := p.mapping["x"].([]byte)
+	if !ok {
+		t.Fatalf("got %T", p.mapping["x"])
+	}
+	if len(b) != 32 {
+		t.Fatalf("len=%d", len(b))
+	}
+}
+
+func TestTryParseOversizedHexInteger(t *testing.T) {
+	hash := "6501bc346e2ad6eecae3bcf7eee78ac21b1a03bdc4fda879a4d24793c1f08db7"
+	b, ok := tryParseOversizedHexInteger("0x" + hash)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if len(b) != 32 {
+		t.Fatalf("len=%d", len(b))
+	}
+}
+
+func TestDecodeHexBytesString(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []byte
+		err  bool
+	}{
+		{"deadbeef", []byte{0xde, 0xad, 0xbe, 0xef}, false},
+		{"0xdeadbeef", []byte{0xde, 0xad, 0xbe, 0xef}, false},
+		{"0X01", []byte{0x01}, false},
+		{"abc", nil, true},
+		{"ghij", nil, true},
+	}
+	for _, tt := range tests {
+		got, err := decodeHexBytes(tt.in)
+		if (err != nil) != tt.err {
+			t.Errorf("decodeHexBytes(%q): err=%v wantErr=%v", tt.in, err, tt.err)
+			continue
+		}
+		if !tt.err && string(got) != string(tt.want) {
+			t.Errorf("decodeHexBytes(%q) = %x, want %x", tt.in, got, tt.want)
+		}
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -292,6 +292,9 @@ func (p *parser) valueInteger(it item) (any, tomlType) {
 		// So mark the former as a bug but the latter as a legitimate user
 		// error.
 		if e, ok := err.(*strconv.NumError); ok && e.Err == strconv.ErrRange {
+			if b, ok := tryParseOversizedHexInteger(it.val); ok {
+				return b, p.typeOfPrimitive(it)
+			}
 			p.panicErr(it, errParseRange{i: it.val, size: "int64"})
 		} else {
 			p.bug("Expected integer value, but got '%s'.", it.val)


### PR DESCRIPTION
## Summary

- Parse `0x` integer literals that do not fit in `int64` as byte slices (e.g. SHA-256 hashes).
- Decode hex strings and small `0x` integer literals into `[]byte` and `[N]byte` fields.

Fixes #448.

## Test plan

- [x] `go test ./...`
- [x] `TestDecodeHexBytes` covers `0x` literal, quoted hex string, `[32]byte`, and `0xff`