### PR TITLE
reject negative integers when decoding into uint and uint64

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -512,9 +512,10 @@ func (md *MetaData) unifyInt(data any, rv reflect.Value) error {
 		rv.SetInt(num)
 	case rvk >= reflect.Uint && rvk <= reflect.Uint64:
 		unum := uint64(num)
-		if rvk == reflect.Uint8 && (num < 0 || unum > math.MaxUint8) ||
-			rvk == reflect.Uint16 && (num < 0 || unum > math.MaxUint16) ||
-			rvk == reflect.Uint32 && (num < 0 || unum > math.MaxUint32) {
+		if num < 0 ||
+			rvk == reflect.Uint8 && unum > math.MaxUint8 ||
+			rvk == reflect.Uint16 && unum > math.MaxUint16 ||
+			rvk == reflect.Uint32 && unum > math.MaxUint32 {
 			return md.parseErr(errParseRange{i: num, size: rvk.String()})
 		}
 		rv.SetUint(unum)

--- a/decode_test.go
+++ b/decode_test.go
@@ -165,6 +165,16 @@ func TestDecodeErrors(t *testing.T) {
 			`toml: line 1 (last key "V"): 999999999999999 is out of the safe float32 range`,
 		},
 		{
+			&struct{ V uint64 }{},
+			`V = -1`,
+			`toml: line 1 (last key "V"): -1 is out of range for uint64`,
+		},
+		{
+			&struct{ V uint }{},
+			`V = -5`,
+			`toml: line 1 (last key "V"): -5 is out of range for uint`,
+		},
+		{
 			&struct{ V string }{},
 			`V = 5`,
 			`toml: line 1 (last key "V"): incompatible types: TOML value has type int64; destination has type string`,


### PR DESCRIPTION
unifyInt only checks num < 0 for the uint8/uint16/uint32 cases, so a negative TOML integer decoded into a uint or uint64 field wraps silently instead of erroring: A = -1 into uint64 gives 18446744073709551615. Move the num < 0 check so it covers every unsigned width.