### PR TITLE
range-check int and uint widths in unifyInt

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -504,18 +504,13 @@ func (md *MetaData) unifyInt(data any, rv reflect.Value) error {
 	rvk := rv.Kind()
 	switch {
 	case rvk >= reflect.Int && rvk <= reflect.Int64:
-		if (rvk == reflect.Int8 && (num < math.MinInt8 || num > math.MaxInt8)) ||
-			(rvk == reflect.Int16 && (num < math.MinInt16 || num > math.MaxInt16)) ||
-			(rvk == reflect.Int32 && (num < math.MinInt32 || num > math.MaxInt32)) {
+		if rv.OverflowInt(num) {
 			return md.parseErr(errParseRange{i: num, size: rvk.String()})
 		}
 		rv.SetInt(num)
 	case rvk >= reflect.Uint && rvk <= reflect.Uint64:
 		unum := uint64(num)
-		if num < 0 ||
-			rvk == reflect.Uint8 && unum > math.MaxUint8 ||
-			rvk == reflect.Uint16 && unum > math.MaxUint16 ||
-			rvk == reflect.Uint32 && unum > math.MaxUint32 {
+		if num < 0 || rv.OverflowUint(unum) {
 			return md.parseErr(errParseRange{i: num, size: rvk.String()})
 		}
 		rv.SetUint(unum)

--- a/decode_test.go
+++ b/decode_test.go
@@ -231,13 +231,34 @@ func TestDecodeErrors(t *testing.T) {
 			`V.N = [1,2,3]`,
 			`toml: line 1 (last key "V.N"): expected array length 1; got TOML array of length 3`,
 		},
+		{
+			&struct{ Value int8 }{},
+			`value = 500`,
+			`toml: line 1 (last key "value"): 500 is out of range for int8`,
+		},
+
+		// Make sure int overflows on 32bit systems on >32bit values. Note this test
+		// should only fail on 32bit systems.
+		{
+			&struct{ Value int }{},
+			fmt.Sprintf(`value = %d`, math.MaxInt32+int64(1)),
+			map[int]string{32: `toml: line 1 (last key "value"): 2147483648 is out of range for int`}[strconv.IntSize],
+		},
+		{
+			&struct{ Value uint }{},
+			fmt.Sprintf(`value = %d`, math.MaxUint32+int64(1)),
+			map[int]string{32: `toml: line 1 (last key "value"): 4294967296 is out of range for uint`}[strconv.IntSize],
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			_, err := Decode(tt.toml, tt.s)
-			if err == nil {
+			if err == nil && tt.wantErr != "" {
 				t.Fatal("err is nil")
+			}
+			if tt.wantErr == "" {
+				return
 			}
 			if err.Error() != tt.wantErr {
 				t.Errorf("\nhave: %q\nwant: %q", err, tt.wantErr)
@@ -247,14 +268,14 @@ func TestDecodeErrors(t *testing.T) {
 }
 
 func TestDecodeIgnoreFields(t *testing.T) {
-	const input = `
-Number = 123
-- = 234
-`
 	var s struct {
 		Number int `toml:"-"`
 	}
-	if _, err := Decode(input, &s); err != nil {
+	_, err := Decode(`
+		Number = 123
+		- = 234
+	 `, &s)
+	if err != nil {
 		t.Fatal(err)
 	}
 	if s.Number != 0 {
@@ -285,24 +306,23 @@ func TestDecodePointers(t *testing.T) {
 		BaseObject: &Object{"BASE", "da base"},
 	}
 
-	ex1 := `
-Strptr = "blah"
-Strptrs = ["abc", "def"]
-
-[NamedObject.foo]
-Type = "FOO"
-Description = "fooooo!!!"
-
-[NamedObject.bar]
-Type = "BAR"
-Description = "ba-ba-ba-ba-barrrr!!!"
-
-[BaseObject]
-Type = "BASE"
-Description = "da base"
-`
 	dict := new(Dict)
-	_, err := Decode(ex1, dict)
+	_, err := Decode(`
+		Strptr = "blah"
+		Strptrs = ["abc", "def"]
+
+		[NamedObject.foo]
+		Type = "FOO"
+		Description = "fooooo!!!"
+
+		[NamedObject.bar]
+		Type = "BAR"
+		Description = "ba-ba-ba-ba-barrrr!!!"
+
+		[BaseObject]
+		Type = "BASE"
+		Description = "da base"
+	`, dict)
 	if err != nil {
 		t.Errorf("Decode error: %v", err)
 	}
@@ -330,44 +350,6 @@ func TestDecodeArrayWrongSize(t *testing.T) {
 	var s1 sphere
 	if _, err := Decode(`center = [0.1, 2.3]`, &s1); err == nil {
 		t.Fatal("Expected array type mismatch error")
-	}
-}
-
-func TestDecodeIntOverflow(t *testing.T) {
-	type table struct {
-		Value int8
-	}
-	var tab table
-	if _, err := Decode(`value = 500`, &tab); err == nil {
-		t.Fatal("Expected integer out-of-bounds error.")
-	}
-}
-
-// A value that fits int64 but not a 32-bit int/uint must still be rejected when
-// decoding into the platform-sized int/uint kinds, not silently truncated. This
-// only bites on a 32-bit build, where int/uint are 32 bits wide; on a 64-bit
-// build both values fit, so the decode succeeds and the assertion is a no-op,
-// hence the strconv.IntSize gate. The thresholds also differ per kind: int wraps
-// past MaxInt32, uint past MaxUint32.
-func TestDecodeIntPlatformOverflow(t *testing.T) {
-	var i struct{ Value int }
-	_, err := Decode(fmt.Sprintf(`value = %d`, math.MaxInt32+int64(1)), &i)
-	if strconv.IntSize == 32 {
-		if err == nil {
-			t.Fatalf("int: expected out-of-range error on %d-bit int, got value %d", strconv.IntSize, i.Value)
-		}
-	} else if err != nil {
-		t.Fatalf("int: unexpected error on %d-bit int: %v", strconv.IntSize, err)
-	}
-
-	var u struct{ Value uint }
-	_, err = Decode(fmt.Sprintf(`value = %d`, math.MaxUint32+int64(1)), &u)
-	if strconv.IntSize == 32 {
-		if err == nil {
-			t.Fatalf("uint: expected out-of-range error on %d-bit uint, got value %d", strconv.IntSize, u.Value)
-		}
-	} else if err != nil {
-		t.Fatalf("uint: unexpected error on %d-bit uint: %v", strconv.IntSize, err)
 	}
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -344,8 +344,11 @@ func TestDecodeIntOverflow(t *testing.T) {
 }
 
 // A value that fits int64 but not a 32-bit int/uint must still be rejected when
-// decoding into the platform-sized int/uint kinds, not silently truncated. The
-// thresholds differ per kind: int wraps past MaxInt32, uint past MaxUint32.
+// decoding into the platform-sized int/uint kinds, not silently truncated. This
+// only bites on a 32-bit build, where int/uint are 32 bits wide; on a 64-bit
+// build both values fit, so the decode succeeds and the assertion is a no-op,
+// hence the strconv.IntSize gate. The thresholds also differ per kind: int wraps
+// past MaxInt32, uint past MaxUint32.
 func TestDecodeIntPlatformOverflow(t *testing.T) {
 	var i struct{ Value int }
 	_, err := Decode(fmt.Sprintf(`value = %d`, math.MaxInt32+int64(1)), &i)

--- a/decode_test.go
+++ b/decode_test.go
@@ -344,12 +344,11 @@ func TestDecodeIntOverflow(t *testing.T) {
 }
 
 // A value that fits int64 but not a 32-bit int/uint must still be rejected when
-// decoding into the platform-sized int/uint kinds, not silently truncated.
+// decoding into the platform-sized int/uint kinds, not silently truncated. The
+// thresholds differ per kind: int wraps past MaxInt32, uint past MaxUint32.
 func TestDecodeIntPlatformOverflow(t *testing.T) {
-	const v = math.MaxInt32 + int64(1)
-
 	var i struct{ Value int }
-	_, err := Decode(fmt.Sprintf(`value = %d`, v), &i)
+	_, err := Decode(fmt.Sprintf(`value = %d`, math.MaxInt32+int64(1)), &i)
 	if strconv.IntSize == 32 {
 		if err == nil {
 			t.Fatalf("int: expected out-of-range error on %d-bit int, got value %d", strconv.IntSize, i.Value)
@@ -359,7 +358,7 @@ func TestDecodeIntPlatformOverflow(t *testing.T) {
 	}
 
 	var u struct{ Value uint }
-	_, err = Decode(fmt.Sprintf(`value = %d`, v), &u)
+	_, err = Decode(fmt.Sprintf(`value = %d`, math.MaxUint32+int64(1)), &u)
 	if strconv.IntSize == 32 {
 		if err == nil {
 			t.Fatalf("uint: expected out-of-range error on %d-bit uint, got value %d", strconv.IntSize, u.Value)

--- a/decode_test.go
+++ b/decode_test.go
@@ -343,6 +343,32 @@ func TestDecodeIntOverflow(t *testing.T) {
 	}
 }
 
+// A value that fits int64 but not a 32-bit int/uint must still be rejected when
+// decoding into the platform-sized int/uint kinds, not silently truncated.
+func TestDecodeIntPlatformOverflow(t *testing.T) {
+	const v = math.MaxInt32 + int64(1)
+
+	var i struct{ Value int }
+	_, err := Decode(fmt.Sprintf(`value = %d`, v), &i)
+	if strconv.IntSize == 32 {
+		if err == nil {
+			t.Fatalf("int: expected out-of-range error on %d-bit int, got value %d", strconv.IntSize, i.Value)
+		}
+	} else if err != nil {
+		t.Fatalf("int: unexpected error on %d-bit int: %v", strconv.IntSize, err)
+	}
+
+	var u struct{ Value uint }
+	_, err = Decode(fmt.Sprintf(`value = %d`, v), &u)
+	if strconv.IntSize == 32 {
+		if err == nil {
+			t.Fatalf("uint: expected out-of-range error on %d-bit uint, got value %d", strconv.IntSize, u.Value)
+		}
+	} else if err != nil {
+		t.Fatalf("uint: unexpected error on %d-bit uint: %v", strconv.IntSize, err)
+	}
+}
+
 func TestDecodeFloatOverflow(t *testing.T) {
 	tests := []struct {
 		value    string


### PR DESCRIPTION
unifyInt only range-checks the fixed-width int and uint kinds; reflect.Int and reflect.Uint fall through unchecked, so on a 32-bit build a value above 2^31-1 decoded into an int or uint field is silently truncated instead of rejected. Spotted it reading the range checks next to the uint fix. Swapped the hand-rolled per-width comparisons for rv.OverflowInt and rv.OverflowUint, which are width-aware and also cover the platform-sized kinds. The num < 0 guard stays so negatives into unsigned still error.