### PR TITLE
use FormatFloat for floats in unifyText

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -562,7 +562,7 @@ func (md *MetaData) unifyText(data any, v encoding.TextUnmarshaler) error {
 	case int64:
 		s = fmt.Sprintf("%d", sdata)
 	case float64:
-		s = fmt.Sprintf("%f", sdata)
+		s = strconv.FormatFloat(sdata, 'g', -1, 64)
 	default:
 		return md.badtype("primitive (string-like)", data)
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -814,6 +814,35 @@ func TestDecodeTextUnmarshaler(t *testing.T) {
 	}
 }
 
+// recordText is a TextUnmarshaler that keeps the exact bytes it was handed.
+type recordText struct{ text string }
+
+func (r *recordText) UnmarshalText(b []byte) error { r.text = string(b); return nil }
+
+func TestDecodeTextUnmarshalerFloat(t *testing.T) {
+	tests := []struct {
+		toml string
+		want string
+	}{
+		{"v = 3.141592653589793", "3.141592653589793"},
+		{"v = 1e-10", "1e-10"},
+		{"v = 1.5e300", "1.5e+300"},
+		{"v = 0.1", "0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			var s struct{ V recordText }
+			if _, err := Decode(tt.toml, &s); err != nil {
+				t.Fatal(err)
+			}
+			if s.V.text != tt.want {
+				t.Errorf("\nhave: %s\nwant: %s", s.V.text, tt.want)
+			}
+		})
+	}
+}
+
 func TestDecodeDuration(t *testing.T) {
 	tests := []struct {
 		in                  any


### PR DESCRIPTION
unifyText converts a primitive TOML value to text before handing it to a type's UnmarshalText, and the float64 branch ran through fmt.Sprintf("%f", ...). That verb pins six fractional digits and drops the exponent, so what the unmarshaler actually sees is mangled: decoding 1e-10 into such a type yields "0.000000" which parses straight back to zero, 3.141592653589793 arrives as "3.141593", and 1.5e300 balloons into a ~300-digit integer string. I spotted it reading the float handling alongside unifyString, which already uses strconv.FormatFloat with 'g' and -1 precision, so the two paths disagree on identical input.

Moved the branch onto strconv.FormatFloat(sdata, 'g', -1, 64), the shortest form that round-trips, matching unifyString and the encoder. This is the only layer the conversion can be corrected at, since the unmarshaler is given bytes rather than a float64 and a caller cannot recover precision once we have already truncated it. Left as-is it is silent data loss for any custom scalar type fed a TOML float, with small magnitudes collapsing to zero being the worst of it; added a test covering the precision, exponent and small-value cases.