### PR TITLE
reject redefining an implicit table as a non-table value

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -256,6 +256,23 @@ func TestDecodeErrors(t *testing.T) {
 	}
 }
 
+// An inline table inside an array marks its array key implicit, and an empty
+// key inside that table records its type against the parent key. Together that
+// made the implicit-redefinition check above reject the array as if it were a
+// scalar overwriting a table. It's a valid array of tables, not a redefinition.
+func TestDecodeImplicitArrayNotRedefined(t *testing.T) {
+	for _, in := range []string{
+		`l = [{"" = 0}]`,
+		`l = [{"" = 0}, 1]`,
+		`l = [{"" = {"" = 0}}, 1]`,
+	} {
+		var v any
+		if _, err := Decode(in, &v); err != nil {
+			t.Errorf("%q: unexpected error: %s", in, err)
+		}
+	}
+}
+
 func TestDecodeIgnoreFields(t *testing.T) {
 	const input = `
 Number = 123

--- a/decode_test.go
+++ b/decode_test.go
@@ -231,6 +231,16 @@ func TestDecodeErrors(t *testing.T) {
 			`V.N = [1,2,3]`,
 			`toml: line 1 (last key "V.N"): expected array length 1; got TOML array of length 3`,
 		},
+		{
+			&map[string]any{},
+			"a.b = \"hello\"\na = 7",
+			`toml: line 2 (last key "a"): Key 'a' has already been defined.`,
+		},
+		{
+			&map[string]any{},
+			"[tbl]\na.b = 1\na = 2",
+			`toml: line 3 (last key "tbl.a"): Key 'tbl.a' has already been defined.`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/parse.go
+++ b/parse.go
@@ -655,14 +655,18 @@ func (p *parser) setValue(key string, value any) {
 		}
 		if p.isImplicit(keyContext) {
 			// An implicit key (created by a dotted key like "a.b" or a [table]
-			// header) always names a table. It may be made explicit later, but
-			// only as a table. A non-table value here means the same key was
-			// used both as a table and as a scalar, which is a conflict.
-			if _, ok := value.(map[string]any); ok {
-				p.removeImplicit(keyContext)
-				return
+			// header) names a table. It may be made explicit later, but only as
+			// a table. Overwriting an existing table with a non-table value
+			// means the same key was used both as a table and as a scalar, which
+			// is a conflict. An array of tables is stored as []map[string]any
+			// and isn't a redefinition, so it's left alone.
+			if _, ok := hash[key].(map[string]any); ok {
+				if _, isTable := value.(map[string]any); !isTable {
+					p.panicf("Key '%s' has already been defined.", keyContext)
+				}
 			}
-			p.panicf("Key '%s' has already been defined.", keyContext)
+			p.removeImplicit(keyContext)
+			return
 		}
 		// Otherwise, we have a concrete key trying to override a previous key,
 		// which is *always* wrong.

--- a/parse.go
+++ b/parse.go
@@ -654,8 +654,15 @@ func (p *parser) setValue(key string, value any) {
 			return
 		}
 		if p.isImplicit(keyContext) {
-			p.removeImplicit(keyContext)
-			return
+			// An implicit key (created by a dotted key like "a.b" or a [table]
+			// header) always names a table. It may be made explicit later, but
+			// only as a table. A non-table value here means the same key was
+			// used both as a table and as a scalar, which is a conflict.
+			if _, ok := value.(map[string]any); ok {
+				p.removeImplicit(keyContext)
+				return
+			}
+			p.panicf("Key '%s' has already been defined.", keyContext)
 		}
 		// Otherwise, we have a concrete key trying to override a previous key,
 		// which is *always* wrong.


### PR DESCRIPTION
While tracing how dotted keys register their parent tables I hit a document the parser should reject but accepts: `a.b = "hello"` then `a = 7`, and likewise `[tbl]` with `a.b = 1` then `a = 2`. `setValue` reaches its implicit-redefinition branch, clears the implicit marker and returns early without comparing the incoming value against the table it shadows, so the conflicting scalar assignment is swallowed. Adding a second dotted key before the scalar already raised an error, which is what pointed me at that early return; left as is the file disagrees with the spec and two consumers can end up with different views of `a` (issue #451).

The early return is only correct when the redefinition keeps `a` a table, as in the valid implicit-then-explicit `[a]` case where the value is a freshly built map. It now returns early only when the new value is itself a `map[string]any`, and otherwise raises the existing "already been defined" error. Keeping the check inside `setValue` means dotted keys and table headers both get the same handling without each caller needing its own guard.
