### PR TITLE
encode: don't shift local datetimes/dates/times to UTC

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -226,12 +226,7 @@ func (enc *Encoder) eElement(rv reflect.Value) {
 		case internal.LocalTime:
 			format = "15:04:05.999999999"
 		}
-		switch v.Location() {
-		default:
-			enc.write(v.Format(format))
-		case internal.LocalDatetime, internal.LocalDate, internal.LocalTime:
-			enc.write(v.In(time.UTC).Format(format))
-		}
+		enc.write(v.Format(format))
 		return
 	case Marshaler:
 		s, err := v.MarshalTOML()

--- a/encode_test.go
+++ b/encode_test.go
@@ -25,15 +25,15 @@ func TestRoundtrip(t *testing.T) {
 		LargeFloat float64   `toml:"large_float"`
 	}
 
-	doc := `
-age = 13
-cats = ["one", "two", "three"]
-pi = 3.145
-perfection = [11, 2, 3, 4]
-dob = 2012-01-02T15:16:17Z
-ip = "192.168.59.254"
-large_float = 5e+22
-`[1:]
+	doc := strings.ReplaceAll(`
+		age = 13
+		cats = ["one", "two", "three"]
+		pi = 3.145
+		perfection = [11, 2, 3, 4]
+		dob = 2012-01-02T15:16:17Z
+		ip = "192.168.59.254"
+		large_float = 5e+22
+	`[1:], "\t", "")
 
 	want := scan{
 		Age:        13,
@@ -60,6 +60,43 @@ large_float = 5e+22
 	}
 	if string(out) != doc {
 		t.Errorf("\nhave:\n%v\nwant:\n%v", string(out), doc)
+	}
+}
+
+// local date types have no offset – encoding must emit the wall clock value as
+// present in the time.Time.
+//
+// Previously the encoder shifted them to UTC first, which corrupted the value
+// on any machine not in UTC (e.g. a local time of "07:32:00" was emitted as
+// "11:32:00" in UTC-4).
+func TestEncodeRoundtripLocalDatetime(t *testing.T) {
+	docs := []string{
+		"d = 1987-07-05T17:45:00\n",
+		"d = 1977-12-21T10:32:00.555\n",
+		"d = 1987-07-05\n",
+		"d = 17:45:00\n",
+		"d = 10:32:00.555\n",
+		"d = 2024-03-10T23:30:00\n", // Near a day boundary, a UTC shift could even roll the date over.
+		"d = 23:30:00\n",
+	}
+	for _, doc := range docs {
+		t.Run("", func(t *testing.T) {
+			var m map[string]any
+			_, err := Decode(doc, &m)
+			if err != nil {
+				t.Fatalf("decode %q: %s", doc, err)
+			}
+
+			var buf bytes.Buffer
+			err = NewEncoder(&buf).Encode(m)
+			if err != nil {
+				t.Fatalf("encode %q: %s", doc, err)
+			}
+
+			if buf.String() != doc {
+				t.Errorf("\nhave: %q\nwant: %q", buf.String(), doc)
+			}
+		})
 	}
 }
 

--- a/internal/tag/rm.go
+++ b/internal/tag/rm.go
@@ -100,12 +100,15 @@ func untag(typed map[string]any) (any, error) {
 }
 
 func parseTime(v, format string, l *time.Location) (time.Time, error) {
-	t, err := time.Parse(format, v)
+	if l == nil {
+		l = time.UTC
+	}
+	// Parse the wall-clock value directly into the target location, matching
+	// how the decoder builds local datetimes/dates/times. Using time.Parse and
+	// then .In(l) would instead shift the value by l's offset.
+	t, err := time.ParseInLocation(format, v, l)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("could not parse %q as a datetime: %w", v, err)
-	}
-	if l != nil {
-		t = t.In(l)
 	}
 	return t, nil
 }


### PR DESCRIPTION
I noticed that local datetimes, dates, and times don't survive a round trip on any machine that isn't in UTC: decoding then re-encoding shifts the value by the local timezone offset.

```go
var v map[string]any
toml.Decode("t = 07:32:00", &v)

var buf bytes.Buffer
toml.NewEncoder(&buf).Encode(v)
// buf is "t = 11:32:00\n" on a UTC-4 machine
```

A local time of `07:32:00` comes back as `11:32:00`, and a near-midnight local datetime can even roll over to a different day. These types have no offset, so their value is the literal wall-clock time — the decoder already stores it that way via `time.ParseInLocation`, but the encoder ran `v.In(time.UTC)` before formatting, which moved the wall clock.

The fix formats the wall-clock value directly. I also updated the `toml-test` helper's `parseTime` to build local times with `time.ParseInLocation` so it constructs them the same way the decoder does (the previous `time.Parse(...).In(l)` and the encoder's UTC shift were cancelling each other out, which is why the conformance suite didn't catch this).

Tests pass under several timezones (`UTC`, `America/New_York`, `Pacific/Kiritimati`); added a round-trip test for the local types. The existing `ossfuzz` round-trip harness didn't surface this because it only re-decodes the output, it doesn't compare values.
