### PR TITLE
decode: allow merging map values into existing data

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -120,12 +120,19 @@ const (
 type Decoder struct {
 	r       io.Reader
 	maxNest int
+	merge   bool
 }
 
 // NewDecoder creates a new Decoder.
 func NewDecoder(r io.Reader) *Decoder {
 	return &Decoder{r: r, maxNest: 128}
 }
+
+// Merge sets whether dec merges new data with old data in values it decodes to.
+// When true, dec will merge the existing struct fields and map values rather
+// than replacing them. Slices (lists) will still be replaced - implement
+// Unmarshaller on a custom slice type to merge slices.
+func (dec *Decoder) Merge(merge bool) { dec.merge = merge }
 
 // MaxTableNesting sets the maximum table nesting to prevent using an
 // inordinate amount of system resources on deeply nested tables.
@@ -183,6 +190,7 @@ func (dec *Decoder) Decode(v any) (MetaData, error) {
 		decoded: make(map[string]struct{}, len(p.ordered)),
 		context: nil,
 		data:    data,
+		merge:   dec.merge,
 	}
 	return md, md.unify(p.mapping, rv)
 }
@@ -347,6 +355,22 @@ func (md *MetaData) unifyStruct(mapping any, rv reflect.Value) error {
 	return nil
 }
 
+func (md *MetaData) mapVal(m reflect.Value, key string) reflect.Value {
+	if !md.merge {
+		return reflect.Indirect(reflect.New(m.Type().Elem()))
+	}
+	v := m.MapIndex(reflect.ValueOf(key))
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	if !v.IsValid() {
+		return reflect.Indirect(reflect.New(m.Type().Elem()))
+	}
+	setter := reflect.New(v.Type()).Elem()
+	setter.Set(v)
+	return setter
+}
+
 func (md *MetaData) unifyMap(mapping any, rv reflect.Value) error {
 	keyType := rv.Type().Key().Kind()
 	if keyType != reflect.String && keyType != reflect.Interface {
@@ -356,7 +380,7 @@ func (md *MetaData) unifyMap(mapping any, rv reflect.Value) error {
 
 	tmap, ok := mapping.(map[string]any)
 	if !ok {
-		if tmap == nil {
+		if mapping == nil {
 			return nil
 		}
 		return md.badtype("map", mapping)
@@ -368,7 +392,7 @@ func (md *MetaData) unifyMap(mapping any, rv reflect.Value) error {
 		md.decoded[md.context.add(k).String()] = struct{}{}
 		md.context = append(md.context, k)
 
-		rvval := reflect.Indirect(reflect.New(rv.Type().Elem()))
+		rvval := md.mapVal(rv, k)
 
 		err := md.unify(v, indirect(rvval))
 		if err != nil {

--- a/decode_test.go
+++ b/decode_test.go
@@ -1272,3 +1272,104 @@ func TestMaxTableNesting(t *testing.T) {
 		})
 	}
 }
+
+type sliceMergerElem struct {
+	ID  string `toml:"id"`
+	Val any    `toml:"value"`
+}
+type sliceMerger []sliceMergerElem
+
+func (m *sliceMerger) UnmarshalTOML(data any) error {
+	ds := data.([]map[string]any)
+	for _, dm := range ds {
+		merged := false
+		for j, ov := range *m {
+			if ov.ID != dm["id"] {
+				continue
+			}
+			merged = true
+			(*m)[j].Val = dm["value"]
+			break
+		}
+		if !merged {
+			*m = append(*m, sliceMergerElem{ID: dm["id"].(string), Val: dm["value"]})
+		}
+	}
+	return nil
+}
+
+func TestMerge(t *testing.T) {
+	type pos struct {
+		Lat float64 `toml:"lat"`
+		Lng float64 `toml:"lng"`
+	}
+	m := map[string]any{
+		"places": map[string]pos{
+			"Minneapolis": {44.916951, -93.027389},
+			"Fantasia":    {723.11217, -4223.937721},
+		},
+		"things": sliceMerger{
+			{ID: "boat", Val: "my boat"},
+			{ID: "minis", Val: []string{"malifaux", "warmahordes"}},
+		},
+	}
+	r := bytes.NewReader([]byte(`
+[places.Seattle]
+  lat = 47.587909
+  lng = -122.300158
+[places.Fantasia]
+  lng = -420
+[[things]]
+  id = "tools"
+  value = ["hammer", "screwdriver"]
+[[things]]
+  id = "minis"
+  value = "kingdom death"
+`))
+	dec := NewDecoder(r)
+	dec.Merge(true)
+	_, err := dec.Decode(&m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	places, ok := m["places"].(map[string]pos)
+	if !ok {
+		t.Fatalf("places was expected to stay map[string]pos but was replaced with %T", m["places"])
+	}
+	minne := places["Minneapolis"]
+	expectedMinne := pos{44.916951, -93.027389}
+	if minne != expectedMinne {
+		t.Fatalf("Minneapolis position was not as expected\nhave: %v\nwant: %v", minne, expectedMinne)
+	}
+	seattle := places["Seattle"]
+	expectedSeattle := pos{47.587909, -122.300158}
+	if seattle != expectedSeattle {
+		t.Fatalf("Seattle position was not as expected\nhave: %v\nwant: %v", seattle, expectedSeattle)
+	}
+	fantasia := places["Fantasia"]
+	expectedFantasia := pos{723.11217, -420}
+	if fantasia != expectedFantasia {
+		t.Fatalf("Fantasia longitude was not overwritten properly\nhave: %v\nwant: %v", fantasia, expectedFantasia)
+	}
+
+	things := m["things"].(sliceMerger)
+	expectedThings := 3
+	if len(things) != expectedThings {
+		t.Fatalf("things is an unexpected length\nhave: %d\nwant: %d", len(things), expectedThings)
+	}
+	boat := things[0]
+	expectedBoat := "my boat"
+	if boat.Val != expectedBoat {
+		t.Fatalf("boat value was removed/replaced\nhave: %v\nwant: %v", boat.Val, expectedBoat)
+	}
+	minis := things[1]
+	expectedMinis := "kingdom death"
+	if !reflect.DeepEqual(minis.Val, expectedMinis) {
+		t.Fatalf("minis value was not overwritten\nhave: %v\nwant: %v", minis.Val, expectedMinis)
+	}
+	tools := things[2]
+	expectedTools := []any{"hammer", "screwdriver"}
+	if !reflect.DeepEqual(tools.Val, expectedTools) {
+		t.Fatalf("tools value was not added correctly\nhave: %v\nwant: %v", tools.Val, expectedTools)
+	}
+}

--- a/meta.go
+++ b/meta.go
@@ -17,6 +17,7 @@ type MetaData struct {
 	keys    []Key
 	decoded map[string]struct{}
 	data    []byte // Input file; for errors.
+	merge   bool
 }
 
 // IsDefined reports if the key exists in the TOML data.


### PR DESCRIPTION
I have a use case where I'm unmarshaling several files in a `conf.d` directory. For each file I unmarshal, I want values in the file to overwrite values from previous files, but leave all of the other data as is. That works already for structs, but when unmarshaling to a map it would lose data. As far as I could tell, it's just maps - types that implement Unmarshaler work as I expected, structs work as I expected, slices get replaced but that also seems correct.

Since this change *could* potentially break existing uses, I've hidden the behavior behind `decoder.Merge(true)`. If you don't tell the decoder to merge data, it works the same as before.

---

I've added a test, but some rough repro steps:

1. Create a map of "default" data:
```go
dflt := map[string]any{
  "foo": map[string]any{
    "bar": "baz",
  },
}
```
2. Unmarshal a file to the map from [1]:
```go
// someFile:
// [foo]
//   bacon: "eggs"
toml.NewDecoder(someFile).Decode(&dflt)
```
3. Check `dflt["foo"]["bar"]`

what I expected: `"baz"`

what I saw: `nil`

