### PR TITLE
Speed up Key.String by 21%

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -95,8 +95,20 @@ type Key []string
 
 func (k Key) String() string {
 	// This is called quite often, so it's a bit funky to make it faster.
+	size := 0
+	if len(k) > 0 {
+		size = len(k) - 1
+	}
+	for _, kk := range k {
+		if kk == "" {
+			size += 2
+		} else {
+			size += len(kk)
+		}
+	}
+
 	var b strings.Builder
-	b.Grow(len(k) * 25)
+	b.Grow(size)
 outer:
 	for i, kk := range k {
 		if i > 0 {
@@ -104,33 +116,37 @@ outer:
 		}
 		if kk == "" {
 			b.WriteString(`""`)
-		} else {
-			for _, r := range kk {
-				// "Inline" isBareKeyChar
-				if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-') {
-					b.WriteByte('"')
-					b.WriteString(dblQuotedReplacer.Replace(kk))
-					b.WriteByte('"')
-					continue outer
-				}
-			}
-			b.WriteString(kk)
+			continue
 		}
+		for j := 0; j < len(kk); j++ {
+			c := kk[j]
+			// "Inline" isBareKeyChar. Bare TOML keys are ASCII-only, so a
+			// byte scan is enough here and avoids decoding runes.
+			if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-') {
+				b.WriteByte('"')
+				b.WriteString(dblQuotedReplacer.Replace(kk))
+				b.WriteByte('"')
+				continue outer
+			}
+		}
+		b.WriteString(kk)
 	}
 	return b.String()
 }
 
 func (k Key) maybeQuoted(i int) string {
-	if k[i] == "" {
+	kk := k[i]
+	if kk == "" {
 		return `""`
 	}
-	for _, r := range k[i] {
-		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+	for j := 0; j < len(kk); j++ {
+		c := kk[j]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-' {
 			continue
 		}
-		return `"` + dblQuotedReplacer.Replace(k[i]) + `"`
+		return `"` + dblQuotedReplacer.Replace(kk) + `"`
 	}
-	return k[i]
+	return kk
 }
 
 // Like append(), but only increase the cap by 1.


### PR DESCRIPTION
This tightens `Key.String` by doing two small things:

- grow the `strings.Builder` from the key parts instead of the previous `len(k) * 25` heuristic
- scan for TOML bare-key characters by byte, since bare keys are ASCII-only

The public behavior should be unchanged. I also checked the patch with a temporary differential test that compared the new `Key.String` and `maybeQuoted` implementations against the previous rune-scanning implementation over fixed edge cases, empty keys, Unicode, invalid UTF-8 bytes, and 5,000 deterministic randomized keys.

Validation:

```text
go test -count=1 ./...
```

```text
ok  	github.com/BurntSushi/toml	0.210s
?   	github.com/BurntSushi/toml/cmd/toml-test-decoder	[no test files]
?   	github.com/BurntSushi/toml/cmd/toml-test-encoder	[no test files]
?   	github.com/BurntSushi/toml/cmd/tomlv	[no test files]
?   	github.com/BurntSushi/toml/internal	[no test files]
?   	github.com/BurntSushi/toml/internal/tag	[no test files]
?   	github.com/BurntSushi/toml/internal/toml-test	[no test files]
?   	github.com/BurntSushi/toml/ossfuzz	[no test files]
```

Benchmark command:

```text
go test -run '^$' -bench '^BenchmarkKey$' -benchmem -count=20 .
```

`benchstat`:

```text
goos: darwin
goarch: arm64
pkg: github.com/BurntSushi/toml
cpu: Apple M4
       │ baseline-bench.txt │ final-bench.txt │
       │       sec/op       │     sec/op       vs base                │
Key-10           38.72n ± 1%    30.39n ± 2%  -21.52% (p=0.000 n=20)

       │ baseline-bench.txt │ final-bench.txt │
       │        B/op        │      B/op        vs base                │
Key-10           64.00 ± 0%     48.00 ± 0%  -25.00% (p=0.000 n=20)

       │ baseline-bench.txt │ final-bench.txt │
       │     allocs/op      │   allocs/op      vs base                │
Key-10           1.000 ± 0%     1.000 ± 0%  ~ (p=1.000 n=20)
```

I found the candidate while experimenting with Sleepy - https://sleepy.run, then manually reduced the generated diff and validated it locally.
