### PR TITLE
errors: don't panic in ErrorWithPosition when the error has no line number

### DIFF
--- a/error.go
+++ b/error.go
@@ -124,6 +124,9 @@ func (pe ParseError) ErrorWithPosition() string {
 		fmt.Fprintf(b, "toml: error: %s\n\nAt line %d, column %d-%d:\n\n",
 			pe.Message, pe.Position.Line, pe.Position.Col, pe.Position.Col+pe.Position.Len-1)
 	}
+	if pe.Position.Line < 1 { // No line information; can't show a source snippet.
+		return b.String()
+	}
 	if pe.Position.Line > 2 {
 		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-2, expandTab(lines[pe.Position.Line-3]))
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -301,6 +301,30 @@ func TestParseError(t *testing.T) {
 	}
 }
 
+func TestErrorWithPositionNoLine(t *testing.T) {
+	// Some errors are reported without a line number (Position.Line == 0),
+	// such as an incomplete escape at the very end of the input. Rendering
+	// the position used to index lines[-1] and panic.
+	for _, in := range []string{`a = "\`, "b = \"\\x", `c = "`} {
+		var x any
+		_, err := toml.Decode(in, &x)
+		if err == nil {
+			t.Fatalf("%q: err is nil", in)
+		}
+
+		var pErr toml.ParseError
+		if !errors.As(err, &pErr) {
+			t.Fatalf("%q: err is not a ParseError: %#v", in, err)
+		}
+
+		got := pErr.ErrorWithPosition()
+		if !strings.Contains(got, pErr.Message) {
+			t.Errorf("%q: ErrorWithPosition() = %q, want it to contain %q", in, got, pErr.Message)
+		}
+		pErr.ErrorWithUsage()
+	}
+}
+
 var errInvalidValue = errors.New("invalid value")
 
 type Enum1 uint8


### PR DESCRIPTION
Some parse errors carry no line number (`Position.Line == 0`), for example an incomplete escape at the very end of the input like `a = "\`. `ErrorWithPosition` skips the surrounding-context lines in that case but still runs `lines[pe.Position.Line-1]` unconditionally, which indexes `lines[-1]` and panics with `index out of range [-1]`.

This bails out of the source-snippet rendering when the line is unknown and returns just the header, so the error string is still useful and no longer panics. Added a regression test covering a few line-less inputs.

Fixes #498.
