### PR TITLE
decode: limit nested array depth like MaxTableNesting

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -127,8 +127,9 @@ func NewDecoder(r io.Reader) *Decoder {
 	return &Decoder{r: r, maxNest: 128}
 }
 
-// MaxTableNesting sets the maximum table nesting to prevent using an
-// inordinate amount of system resources on deeply nested tables.
+// MaxTableNesting sets the maximum nesting depth for tables and array values to
+// prevent using an inordinate amount of system resources on deeply nested data
+// (and to avoid unrecoverable stack overflows from recursive array parsing).
 //
 // The default is 128. Set to <=0 to disable the limit.
 func (dec *Decoder) MaxTableNesting(l int) { dec.maxNest = l }

--- a/decode_test.go
+++ b/decode_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
 	"reflect"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -1270,5 +1272,83 @@ func TestMaxTableNesting(t *testing.T) {
 				t.Fatalf("wrong error\nhave: %q\nwant: %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// nestedArrayDoc builds "a = [[[…1…]]]" with the given nesting depth.
+func nestedArrayDoc(depth int) string {
+	return "a = " + strings.Repeat("[", depth) + "1" + strings.Repeat("]", depth)
+}
+
+func TestMaxArrayNesting(t *testing.T) {
+	// Mirror TestMaxTableNesting: default limit 128, configurable via
+	// MaxTableNesting, and <=0 disables. Regression for #497 (deeply nested
+	// arrays used to overflow the Go stack with an unrecoverable abort).
+	tests := []struct {
+		name    string
+		doc     string
+		maxNest int // -99 means leave the decoder default
+		wantErr string
+	}{
+		{"default-at-limit", nestedArrayDoc(128), -99, ""},
+		{"default-over-limit", nestedArrayDoc(129), -99, "toml: line 1: too many nested arrays: can have up to 128 nested arrays"},
+		{"disabled-deep", nestedArrayDoc(300), 0, ""},
+		{"custom-at-limit", nestedArrayDoc(5), 5, ""},
+		{"custom-over-limit", nestedArrayDoc(6), 5, "toml: line 1: too many nested arrays: can have up to 5 nested arrays"},
+		// Well above the default limit but shallow enough that the pre-fix
+		// code would still parse successfully; proves the limit fires with a
+		// controlled ParseError rather than only under pathological depth.
+		{"well-over-default", nestedArrayDoc(200), -99, "toml: line 1: too many nested arrays: can have up to 128 nested arrays"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDecoder(strings.NewReader(tt.doc))
+			if tt.maxNest != -99 {
+				d.MaxTableNesting(tt.maxNest)
+			}
+
+			var m map[string]any
+			_, err := d.Decode(&m)
+			if !errorContains(err, tt.wantErr) {
+				t.Fatalf("wrong error\nhave: %q\nwant: %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestIssue497NoStackOverflow is the crash shape from
+// https://github.com/BurntSushi/toml/issues/497: deeply nested arrays used to
+// abort the process with "fatal error: stack overflow".
+//
+// The lowered stack limit is process-wide (see debug.SetMaxStack), so the probe
+// runs in a child process. The child restores the previous limit with defer
+// (using t.Fatal / return, not os.Exit, so deferred restores actually run).
+// Isolation keeps the parent test binary's stack ceiling unchanged even if the
+// child aborts, and avoids polluting later tests under -shuffle.
+func TestIssue497NoStackOverflow(t *testing.T) {
+	const childEnv = "TOML_ISSUE_497_CHILD"
+
+	if os.Getenv(childEnv) == "1" {
+		// Restore whatever stack limit was in effect when this process started.
+		// Must not use os.Exit here: Exit skips deferred functions.
+		defer debug.SetMaxStack(debug.SetMaxStack(4 << 20)) // 4 MiB
+
+		var v any
+		_, err := Decode(nestedArrayDoc(50_000), &v)
+		if err == nil {
+			t.Fatal("expected error for deeply nested arrays, got nil")
+		}
+		if !errorContains(err, "too many nested arrays") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestIssue497NoStackOverflow$", "-test.count=1", "-test.v=false")
+	cmd.Env = append(os.Environ(), childEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("child process failed: %v\n%s", err, out)
 	}
 }

--- a/parse.go
+++ b/parse.go
@@ -14,6 +14,7 @@ import (
 type parser struct {
 	lx         *lexer
 	maxNest    int
+	arrayDepth int      // Current nested array value depth (see valueArray).
 	context    Key      // Full key for the current hash in scope.
 	currentKey string   // Base key name for everything except hashes.
 	pos        Position // Current position in the TOML file.
@@ -397,6 +398,21 @@ func missingLeadingZero(d, l string) bool {
 }
 
 func (p *parser) valueArray(it item) (any, tomlType) {
+	// Bound recursive nesting of array values (e.g. a = [[[[1]]]]). Without
+	// this, sufficiently deep nesting overflows the Go stack with an
+	// unrecoverable runtime abort (#497). Reuse maxNest so one knob covers
+	// both table and array nesting; <=0 disables the limit.
+	if p.maxNest > 0 && p.arrayDepth >= p.maxNest {
+		// Don't use panicItemf: LastKey can be very long and is not useful here.
+		panic(ParseError{
+			Message:  fmt.Sprintf("too many nested arrays: can have up to %d nested arrays", p.maxNest),
+			Position: it.pos.withCol(p.lx.input),
+			Line:     it.pos.Line,
+		})
+	}
+	p.arrayDepth++
+	defer func() { p.arrayDepth-- }()
+
 	p.setType(p.currentKey, tomlArray, it.pos)
 
 	var (


### PR DESCRIPTION
Fixes #497.

Deeply nested array values (`a = [[[[…]]]]`) recurse through `valueArray`/`value`
and abort the process with an unrecoverable stack overflow. Table nesting already
has a default limit of 128 (`Decoder.MaxTableNesting`); array values did not.

This reuses the same `maxNest` limit for nested arrays (default 128; `<=0`
disables) and returns a `ParseError` instead of crashing. Callers that set a
low custom `MaxTableNesting` will now also bound array nesting.

Tests mirror `TestMaxTableNesting`, plus a regression for the issue's deep-nest
shape.