### PR TITLE
fix: avoid panic in ParseError.ErrorWithPosition for Line 0

### DIFF
--- a/error.go
+++ b/error.go
@@ -116,19 +116,35 @@ func (pe ParseError) ErrorWithPosition() string {
 	var (
 		lines = strings.Split(pe.input, "\n")
 		b     = new(strings.Builder)
+		line  = pe.Position.Line
+		col   = pe.Position.Col
+		length = pe.Position.Len
 	)
-	if pe.Position.Len == 1 {
+	// Some lexer errors report Line 0 / invalid ranges (e.g. unfinished
+	// escape at EOF). Fall back to the short error instead of panicking
+	// on lines[line-1] (#498).
+	if line < 1 || line > len(lines) {
+		return pe.Error()
+	}
+	if col < 1 {
+		col = 1
+	}
+	if length < 1 {
+		length = 1
+	}
+
+	if length == 1 {
 		fmt.Fprintf(b, "toml: error: %s\n\nAt line %d, column %d:\n\n",
-			pe.Message, pe.Position.Line, pe.Position.Col)
+			pe.Message, line, col)
 	} else {
 		fmt.Fprintf(b, "toml: error: %s\n\nAt line %d, column %d-%d:\n\n",
-			pe.Message, pe.Position.Line, pe.Position.Col, pe.Position.Col+pe.Position.Len-1)
+			pe.Message, line, col, col+length-1)
 	}
-	if pe.Position.Line > 2 {
-		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-2, expandTab(lines[pe.Position.Line-3]))
+	if line > 2 {
+		fmt.Fprintf(b, "% 7d | %s\n", line-2, expandTab(lines[line-3]))
 	}
-	if pe.Position.Line > 1 {
-		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-1, expandTab(lines[pe.Position.Line-2]))
+	if line > 1 {
+		fmt.Fprintf(b, "% 7d | %s\n", line-1, expandTab(lines[line-2]))
 	}
 
 	/// Expand tabs, so that the ^^^s are at the correct position, but leave
@@ -136,11 +152,11 @@ func (pe ParseError) ErrorWithPosition() string {
 	/// better, but we don't know the tabsize of the user in their editor, which
 	/// can be 8, 4, 2, or something else. We can't know. So leaving it as the
 	/// character index is probably the "most correct".
-	expanded := expandTab(lines[pe.Position.Line-1])
-	diff := len(expanded) - len(lines[pe.Position.Line-1])
+	expanded := expandTab(lines[line-1])
+	diff := len(expanded) - len(lines[line-1])
 
-	fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line, expanded)
-	fmt.Fprintf(b, "% 10s%s%s\n", "", strings.Repeat(" ", pe.Position.Col-1+diff), strings.Repeat("^", pe.Position.Len))
+	fmt.Fprintf(b, "% 7d | %s\n", line, expanded)
+	fmt.Fprintf(b, "% 10s%s%s\n", "", strings.Repeat(" ", col-1+diff), strings.Repeat("^", length))
 	return b.String()
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -446,3 +446,25 @@ At line 2, column 11-13:
 		t.Errorf("\nwant:\n%s\nhave:\n%s", want, have)
 	}
 }
+
+
+func TestParseErrorLineZero(t *testing.T) {
+	// Unfinished escape at EOF used to report Line 0 and panic in
+	// ErrorWithPosition (#498).
+	var v any
+	_, err := toml.Decode(`a = "\`, &v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe toml.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("not a ParseError: %#v", err)
+	}
+	// Must not panic.
+	_ = pe.ErrorWithPosition()
+	_ = pe.ErrorWithUsage()
+	// Short form still works.
+	if pe.Error() == "" {
+		t.Fatal("empty Error()")
+	}
+}


### PR DESCRIPTION
## Description

```go
_, err := toml.Decode(`a = "\`, &v)
var pe toml.ParseError
errors.As(err, &pe)
pe.ErrorWithPosition() // panic: index out of range [-1]
```

Some parse errors report `Position.Line == 0`. `ErrorWithPosition` always did `lines[Line-1]`, which panics for line 0.

## Fix

- If `Line < 1` or past the last line of `input`, return the short `Error()` string.
- Clamp `Col`/`Len` to at least 1 when drawing the caret context.

## Tests

```bash
go test ./... -count=1
```

Added `TestParseErrorLineZero` for the unfinished-escape repro.

## Linked Issue

Closes #498
