### PR TITLE
fix: prevent ErrorWithPosition panic on single-line EOF

### DIFF
--- a/error.go
+++ b/error.go
@@ -117,18 +117,34 @@ func (pe ParseError) ErrorWithPosition() string {
 		lines = strings.Split(pe.input, "\n")
 		b     = new(strings.Builder)
 	)
+	// Clamp line for incomplete single-line EOF errors (Line can be 0).
+	line := pe.Position.Line
+	if line < 1 {
+		line = 1
+	}
+	if line > len(lines) {
+		line = len(lines)
+	}
+	col := pe.Position.Col
+	if col < 1 {
+		col = 1
+	}
+	length := pe.Position.Len
+	if length < 1 {
+		length = 1
+	}
 	if pe.Position.Len == 1 {
 		fmt.Fprintf(b, "toml: error: %s\n\nAt line %d, column %d:\n\n",
-			pe.Message, pe.Position.Line, pe.Position.Col)
+			pe.Message, line, col)
 	} else {
 		fmt.Fprintf(b, "toml: error: %s\n\nAt line %d, column %d-%d:\n\n",
-			pe.Message, pe.Position.Line, pe.Position.Col, pe.Position.Col+pe.Position.Len-1)
+			pe.Message, line, col, col+length-1)
 	}
-	if pe.Position.Line > 2 {
-		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-2, expandTab(lines[pe.Position.Line-3]))
+	if line > 2 {
+		fmt.Fprintf(b, "% 7d | %s\n", line-2, expandTab(lines[line-3]))
 	}
-	if pe.Position.Line > 1 {
-		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-1, expandTab(lines[pe.Position.Line-2]))
+	if line > 1 {
+		fmt.Fprintf(b, "% 7d | %s\n", line-1, expandTab(lines[line-2]))
 	}
 
 	/// Expand tabs, so that the ^^^s are at the correct position, but leave
@@ -136,11 +152,15 @@ func (pe ParseError) ErrorWithPosition() string {
 	/// better, but we don't know the tabsize of the user in their editor, which
 	/// can be 8, 4, 2, or something else. We can't know. So leaving it as the
 	/// character index is probably the "most correct".
-	expanded := expandTab(lines[pe.Position.Line-1])
-	diff := len(expanded) - len(lines[pe.Position.Line-1])
+	expanded := expandTab(lines[line-1])
+	diff := len(expanded) - len(lines[line-1])
 
-	fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line, expanded)
-	fmt.Fprintf(b, "% 10s%s%s\n", "", strings.Repeat(" ", pe.Position.Col-1+diff), strings.Repeat("^", pe.Position.Len))
+	fmt.Fprintf(b, "% 7d | %s\n", line, expanded)
+	caretPad := col - 1 + diff
+	if caretPad < 0 {
+		caretPad = 0
+	}
+	fmt.Fprintf(b, "% 10s%s%s\n", "", strings.Repeat(" ", caretPad), strings.Repeat("^", length))
 	return b.String()
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -446,3 +446,26 @@ At line 2, column 11-13:
 		t.Errorf("\nwant:\n%s\nhave:\n%s", want, have)
 	}
 }
+
+
+func TestErrorWithPositionSingleLineEOF(t *testing.T) {
+	// Incomplete escape at EOF on a single line used to panic in ErrorWithPosition
+	// because the lexer underflowed Position.Line to 0.
+	var v any
+	_, err := toml.Decode(`a = "\`, &v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe toml.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("want ParseError, got %T: %v", err, err)
+	}
+	// Must not panic.
+	out := pe.ErrorWithPosition()
+	if out == "" {
+		t.Fatal("empty ErrorWithPosition")
+	}
+	if pe.Position.Line < 1 {
+		t.Fatalf("Position.Line = %d, want >= 1", pe.Position.Line)
+	}
+}

--- a/lex.go
+++ b/lex.go
@@ -252,9 +252,15 @@ func (lx *lexer) error(err error) stateFn {
 // This is so that unexpected EOF or NL errors don't show on a new blank line.
 func (lx *lexer) errorPrevLine(err error) stateFn {
 	pos := lx.getPos()
-	pos.Line--
+	// On single-line EOF, Line is already 1; do not underflow to 0 (breaks ErrorWithPosition).
+	if pos.Line > 1 {
+		pos.Line--
+	}
 	pos.Len = 1
 	pos.Start = lx.pos - 1
+	if pos.Start < 0 {
+		pos.Start = 0
+	}
 	lx.items <- item{typ: itemError, pos: pos, err: err}
 	return nil
 }


### PR DESCRIPTION
## Summary
`ErrorWithPosition` panicked on single-line EOF errors such as:

```go
_, err := toml.Decode(`a = "\`, &v)
var pe toml.ParseError
errors.As(err, &pe)
pe.ErrorWithPosition() // panic: index out of range [-1]
```

Root cause: `errorPrevLine` always did `pos.Line--`, so a line-1 EOF became `Line: 0`, and `lines[Line-1]` underflowed.

## Fix
- Don't decrement `Line` below 1 in `errorPrevLine`
- Clamp line/column/length in `ErrorWithPosition`

## Test plan
- [x] `go test .`
- [x] `TestErrorWithPositionSingleLineEOF`
- [x] existing `TestErrorPosition`

Fixes #498
