### PR TITLE
fix: return error when encoding with a nil writer

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -134,7 +134,11 @@ type Encoder struct {
 
 // NewEncoder create a new Encoder.
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{w: bufio.NewWriter(w), Indent: "  "}
+	e := &Encoder{Indent: "  "}
+	if w != nil {
+		e.w = bufio.NewWriter(w)
+	}
+	return e
 }
 
 // Encode writes a TOML representation of the Go value to the [Encoder]'s writer.
@@ -142,6 +146,9 @@ func NewEncoder(w io.Writer) *Encoder {
 // An error is returned if the value given cannot be encoded to a valid TOML
 // document.
 func (enc *Encoder) Encode(v any) error {
+	if enc == nil || enc.w == nil {
+		return errors.New("toml: Encoder has nil writer")
+	}
 	rv := eindirect(reflect.ValueOf(v))
 	err := enc.safeEncode(Key([]string{}), rv)
 	if err != nil {

--- a/encode_test.go
+++ b/encode_test.go
@@ -1427,3 +1427,13 @@ k1 = "a"
 		t.Fatalf("\nhave: %s\nwant: %s", h, w)
 	}
 }
+
+func TestEncodeNilWriter(t *testing.T) {
+	err := NewEncoder(nil).Encode(map[string]int{"a": 1})
+	if err == nil {
+		t.Fatal("expected error for nil writer")
+	}
+	if !strings.Contains(err.Error(), "nil writer") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
`NewEncoder(nil)` built a `bufio.Writer` around a nil `io.Writer`, so `Encode` panicked in `Flush`.

Leave the internal buffer nil when the writer is nil, and return a clear error from `Encode`.

## Test plan
- [x] `go test -run TestEncode`
- [x] New unit test for `NewEncoder(nil).Encode(...)`