### PR TITLE
fix: bound ErrorWithPosition against out-of-range positions

### DIFF
--- a/error.go
+++ b/error.go
@@ -117,18 +117,35 @@ func (pe ParseError) ErrorWithPosition() string {
 		lines = strings.Split(pe.input, "\n")
 		b     = new(strings.Builder)
 	)
-	if pe.Position.Len == 1 {
+	// Guard against out-of-range positions (e.g. single-line EOF errors).
+	line := pe.Position.Line
+	if line < 1 {
+		line = 1
+	}
+	if line > len(lines) {
+		line = len(lines)
+	}
+	col := pe.Position.Col
+	if col < 1 {
+		col = 1
+	}
+	length := pe.Position.Len
+	if length < 1 {
+		length = 1
+	}
+
+	if length == 1 {
 		fmt.Fprintf(b, "toml: error: %s\n\nAt line %d, column %d:\n\n",
-			pe.Message, pe.Position.Line, pe.Position.Col)
+			pe.Message, line, col)
 	} else {
 		fmt.Fprintf(b, "toml: error: %s\n\nAt line %d, column %d-%d:\n\n",
-			pe.Message, pe.Position.Line, pe.Position.Col, pe.Position.Col+pe.Position.Len-1)
+			pe.Message, line, col, col+length-1)
 	}
-	if pe.Position.Line > 2 {
-		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-2, expandTab(lines[pe.Position.Line-3]))
+	if line > 2 {
+		fmt.Fprintf(b, "% 7d | %s\n", line-2, expandTab(lines[line-3]))
 	}
-	if pe.Position.Line > 1 {
-		fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line-1, expandTab(lines[pe.Position.Line-2]))
+	if line > 1 {
+		fmt.Fprintf(b, "% 7d | %s\n", line-1, expandTab(lines[line-2]))
 	}
 
 	/// Expand tabs, so that the ^^^s are at the correct position, but leave
@@ -136,11 +153,15 @@ func (pe ParseError) ErrorWithPosition() string {
 	/// better, but we don't know the tabsize of the user in their editor, which
 	/// can be 8, 4, 2, or something else. We can't know. So leaving it as the
 	/// character index is probably the "most correct".
-	expanded := expandTab(lines[pe.Position.Line-1])
-	diff := len(expanded) - len(lines[pe.Position.Line-1])
+	expanded := expandTab(lines[line-1])
+	diff := len(expanded) - len(lines[line-1])
+	spaces := col - 1 + diff
+	if spaces < 0 {
+		spaces = 0
+	}
 
-	fmt.Fprintf(b, "% 7d | %s\n", pe.Position.Line, expanded)
-	fmt.Fprintf(b, "% 10s%s%s\n", "", strings.Repeat(" ", pe.Position.Col-1+diff), strings.Repeat("^", pe.Position.Len))
+	fmt.Fprintf(b, "% 7d | %s\n", line, expanded)
+	fmt.Fprintf(b, "% 10s%s%s\n", "", strings.Repeat(" ", spaces), strings.Repeat("^", length))
 	return b.String()
 }
 

--- a/error_bounds_test.go
+++ b/error_bounds_test.go
@@ -1,0 +1,32 @@
+package toml_test
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestErrorWithPositionOutOfRangeDoesNotPanic(t *testing.T) {
+	var v map[string]any
+	err := toml.Unmarshal([]byte("key = "), &v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	pErr, ok := err.(toml.ParseError)
+	if !ok {
+		t.Fatalf("type %T", err)
+	}
+	// Corrupt position to the single-line EOF class of values from #498.
+	pErr.Position = toml.Position{Line: 0, Col: 0, Len: 0}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic: %v", r)
+		}
+	}()
+	s := pErr.ErrorWithPosition()
+	if s == "" {
+		t.Fatal("empty ErrorWithPosition")
+	}
+	pErr.Position = toml.Position{Line: 999, Col: 1, Len: 1}
+	_ = pErr.ErrorWithPosition()
+}


### PR DESCRIPTION
## What

`ParseError.ErrorWithPosition` clamps `Line` / `Col` / `Len` before indexing the input lines.

## Why

Some parse paths produce positions that are zero or past the last line (e.g. EOF-style errors). Formatting those paniced on slice index.

## Test

- `TestErrorWithPositionOutOfRangeDoesNotPanic`