### PR TITLE
decode: accept inf, -inf, and the max value when decoding into float32

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -457,7 +457,12 @@ func (md *MetaData) unifyFloat64(data any, rv reflect.Value) error {
 	if num, ok := data.(float64); ok {
 		switch rvk {
 		case reflect.Float32:
-			if num < -math.MaxFloat32 || num > math.MaxFloat32 {
+			// Reject only genuine overflow: a finite value whose magnitude is
+			// too large to round to a finite float32. Comparing against
+			// math.MaxFloat32 directly is too strict, because float64 values in
+			// the half-ULP band just above math.MaxFloat32 round to a finite
+			// float32, and ±inf is representable as a float32 as well.
+			if f := float32(num); math.IsInf(float64(f), 0) && !math.IsInf(num, 0) {
 				return md.parseErr(errParseRange{i: num, size: rvk.String()})
 			}
 			fallthrough

--- a/decode_test.go
+++ b/decode_test.go
@@ -1272,3 +1272,60 @@ func TestMaxTableNesting(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeFloat32Range(t *testing.T) {
+	// float32 can hold ±inf, and math.MaxFloat32 is representable. Its shortest
+	// decimal form (which the encoder emits) parses to a float64 fractionally
+	// larger than math.MaxFloat32 but rounds back to a finite float32, so it
+	// must decode without error. Only values that overflow to ±inf are rejected.
+	tests := []struct {
+		doc     string
+		want    float32
+		wantErr string
+	}{
+		{"v = inf", float32(math.Inf(1)), ""},
+		{"v = +inf", float32(math.Inf(1)), ""},
+		{"v = -inf", float32(math.Inf(-1)), ""},
+		{"v = 3.4028235e+38", math.MaxFloat32, ""},
+		{"v = -3.4028235e+38", -math.MaxFloat32, ""},
+		{"v = 3.5e38", 0, "is out of range for float32"},
+		{"v = 1.1e+99", 0, "is out of range for float32"},
+		{"v = -1.1e+99", 0, "is out of range for float32"},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			var s struct{ V float32 }
+			_, err := Decode(tt.doc, &s)
+			if !errorContains(err, tt.wantErr) {
+				t.Fatalf("wrong error for %q\nhave: %q\nwant: %q", tt.doc, err, tt.wantErr)
+			}
+			if tt.wantErr == "" && s.V != tt.want {
+				t.Fatalf("Decode(%q) = %v, want %v", tt.doc, s.V, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncodeDecodeFloat32Inf(t *testing.T) {
+	in := struct {
+		Inf float32 `toml:"inf"`
+		Max float32 `toml:"max"`
+	}{float32(math.Inf(-1)), math.MaxFloat32}
+
+	var buf bytes.Buffer
+	if err := NewEncoder(&buf).Encode(in); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var out struct {
+		Inf float32 `toml:"inf"`
+		Max float32 `toml:"max"`
+	}
+	if _, err := Decode(buf.String(), &out); err != nil {
+		t.Fatalf("round-trip decode of %q failed: %v", buf.String(), err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch:\nhave: %+v\nwant: %+v", out, in)
+	}
+}


### PR DESCRIPTION
Decoding `inf` or `-inf` into a `float32` field currently fails with "is out of range for float32", even though a float32 can represent both. The same happens for `math.MaxFloat32`: its shortest decimal form is `3.4028235e+38`, which parses as a float64 slightly above `math.MaxFloat32` but rounds back to a finite float32.

The check in `unifyFloat64` compared the float64 against `math.MaxFloat32` directly, which is stricter than the actual float32 conversion. Any value in the half-ULP band just above the max rounds down to a finite float32, and `±inf` is representable too.

This also means the encoder can produce output it can't read back: `TestEncodeNaN` encodes a float32 `-inf` as `inf = -inf`, but decoding that into the same struct returned an error.

Reject only genuine overflow instead: a finite value whose float32 conversion is `±inf`. `inf`/`-inf` and values that round to a finite float32 now decode, while `3.5e38` / `1.1e99` are still rejected.