### PR TITLE
encode: reject integers that don't fit in int64

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -278,7 +278,14 @@ func (enc *Encoder) eElement(rv reflect.Value) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		enc.write(strconv.FormatInt(rv.Int(), 10))
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		enc.write(strconv.FormatUint(rv.Uint(), 10))
+		u := rv.Uint()
+		// TOML integers are signed 64 bit, so anything above math.MaxInt64 has no
+		// representation. Writing it anyway produces a document this package's own
+		// decoder rejects with "is out of range for int64".
+		if u > math.MaxInt64 {
+			encPanic(fmt.Errorf("%d is out of range for int64", u))
+		}
+		enc.write(strconv.FormatUint(u, 10))
 	case reflect.Float32:
 		f := rv.Float()
 		if math.IsNaN(f) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -514,6 +514,23 @@ Data = ["Foo", "Bar"]
 	}
 }
 
+// A uint64 that fits in int64 must keep working, and what the encoder writes has to
+// decode back: TOML integers are signed 64 bit, so anything larger has no representation.
+func TestEncodeUint64Roundtrip(t *testing.T) {
+	var buf bytes.Buffer
+	if err := NewEncoder(&buf).Encode(struct{ U uint64 }{math.MaxInt64}); err != nil {
+		t.Fatalf("encode: %s", err)
+	}
+
+	var back struct{ U uint64 }
+	if _, err := Decode(buf.String(), &back); err != nil {
+		t.Fatalf("decoding %q: %s", buf.String(), err)
+	}
+	if back.U != math.MaxInt64 {
+		t.Errorf("have %d, want %d", back.U, uint64(math.MaxInt64))
+	}
+}
+
 func TestEncodeError(t *testing.T) {
 	tests := []struct {
 		in      any
@@ -522,6 +539,8 @@ func TestEncodeError(t *testing.T) {
 		{make(chan int), "unsupported type for key '': chan"},
 		{struct{ C complex128 }{0}, "unsupported type: complex128"},
 		{[]complex128{0}, "unsupported type: complex128"},
+		{struct{ U uint64 }{math.MaxInt64 + 1}, "9223372036854775808 is out of range for int64"},
+		{struct{ U uint64 }{math.MaxUint64}, "18446744073709551615 is out of range for int64"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`eElement` wrote every uint kind with `strconv.FormatUint` and no range check, so a `uint64` above `math.MaxInt64` was emitted as-is:

```go
case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
    enc.write(strconv.FormatUint(rv.Uint(), 10))
```

TOML integers are signed 64 bit, so the document that comes out cannot be read back — not by this package, and not by anything else following the spec:

```
encode uint64(9223372036854775807) -> err=<nil>  out="k = 9223372036854775807\n"
    decode back -> err=<nil>
encode uint64(9223372036854775808) -> err=<nil>  out="k = 9223372036854775808\n"
    decode back -> err=toml: line 1 (last key "k"): 9223372036854775808 is out of range for int64
encode uint64(18446744073709551615) -> err=<nil>  out="k = 18446744073709551615\n"
    decode back -> err=toml: line 1 (last key "k"): 18446744073709551615 is out of range for int64
```

That is against what the encoder documents about itself — encode.go:121, "Encoding Go values without a corresponding TOML representation will return an error". `Decode` rejects the literal at parse.go:295; the encoder writes it anyway.

These are not exotic values: a 64-bit hash exceeds `math.MaxInt64` about half the time, and `^uint64(0)` is a common sentinel. A struct carrying one marshals without complaint and produces a file `Decode` refuses to load.

So error at encode time instead. The check is `u > math.MaxInt64`, so everything representable keeps working — `uint64(math.MaxInt64)` still encodes and round-trips, and `uint8`/`uint16`/`uint32` (and `uint` on a 32-bit platform) can never reach the bound. This mirrors what #483 did on the decode side for the opposite case, a negative TOML integer decoded into a `uint`.

Two cases added to `TestEncodeError` (`uint64` just past the limit, and `MaxUint64`) — both fail on master with "err is nil" — plus `TestEncodeUint64Roundtrip` pinning that `math.MaxInt64` still survives encode → decode. I checked `GOARCH=386` and `GOARCH=arm` compile, since the new cases are in a test file.
