### PR TITLE
Expand Decoder.MaxTableNesting() to arrays, rename to MaxDepth()

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -118,20 +118,20 @@ const (
 // This decoder does not handle cyclic types. Decode will not terminate if a
 // cyclic type is passed.
 type Decoder struct {
-	r       io.Reader
-	maxNest int
+	r        io.Reader
+	maxDepth int
 }
 
 // NewDecoder creates a new Decoder.
 func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r, maxNest: 128}
+	return &Decoder{r: r, maxDepth: 128}
 }
 
-// MaxTableNesting sets the maximum table nesting to prevent using an
-// inordinate amount of system resources on deeply nested tables.
+// MaxDepth sets the maximum table and array depth to prevent using an
+// inordinate amount of system resources on deeply nested objects.
 //
 // The default is 128. Set to <=0 to disable the limit.
-func (dec *Decoder) MaxTableNesting(l int) { dec.maxNest = l }
+func (dec *Decoder) MaxDepth(l int) { dec.maxDepth = l }
 
 var (
 	unmarshalToml = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
@@ -171,7 +171,7 @@ func (dec *Decoder) Decode(v any) (MetaData, error) {
 		return MetaData{}, err
 	}
 
-	p, err := parse(string(data), dec.maxNest)
+	p, err := parse(string(data), dec.maxDepth)
 	if err != nil {
 		return MetaData{}, err
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1244,24 +1244,35 @@ func TestDecodeCustomStructMarkedDecoded(t *testing.T) {
 	}
 }
 
-func TestMaxTableNesting(t *testing.T) {
+func TestMaxDepth(t *testing.T) {
+	var (
+		tbl = func(n int) string { return strings.Repeat(".a", n)[1:] + "=1" }
+		arr = func(n int) string { return "a=" + strings.Repeat("[", n) + "1" + strings.Repeat("]", n) }
+	)
 	tests := []struct {
 		doc     string
 		maxNest int
 		wantErr string
 	}{
-		{"\n\n" + strings.Repeat(".a", 128)[1:] + " = 1", -99, ""},
-		{"\n\n" + strings.Repeat(".a", 129)[1:] + " = 1", -99, "toml: line 3: too many nested tables: can have up to 128 nested tables"},
-		{"\n\n" + strings.Repeat(".a", 300)[1:] + " = 1", 0, ""},
-		{"\n\n" + strings.Repeat(".a", 5)[1:] + " = 1", 5, ""},
-		{"\n\n" + strings.Repeat(".a", 6)[1:] + " = 1", 5, "toml: line 3: too many nested tables: can have up to 5 nested tables"},
+		{"\n\n" + tbl(128), -99, ""},
+		{"\n\n" + tbl(129), -99, "toml: line 3: exceeds maximum table depth of 128"},
+		{"\n\n" + tbl(300), 0, ""},
+		{"\n\n" + tbl(5), 5, ""},
+		{"\n\n" + tbl(6), 5, "toml: line 3: exceeds maximum table depth of 5"},
+
+		{arr(128), -99, ""},
+		{arr(129), -99, `toml: line 1 (last key "a"): exceeds maximum array depth of 128`},
+		{"x=1\n" + arr(129), -99, `toml: line 2 (last key "a"): exceeds maximum array depth of 128`},
+		{arr(300), 0, ``},
+		{arr(5), 5, ""},
+		{arr(6), 5, `toml: line 1 (last key "a"): exceeds maximum array depth of 5`},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			d := NewDecoder(strings.NewReader(tt.doc))
 			if tt.maxNest != -99 {
-				d.MaxTableNesting(tt.maxNest)
+				d.MaxDepth(tt.maxNest)
 			}
 
 			var m map[string]any

--- a/parse.go
+++ b/parse.go
@@ -13,7 +13,8 @@ import (
 
 type parser struct {
 	lx         *lexer
-	maxNest    int
+	maxDepth   int
+	arrDepth   int
 	context    Key      // Full key for the current hash in scope.
 	currentKey string   // Base key name for everything except hashes.
 	pos        Position // Current position in the TOML file.
@@ -29,7 +30,7 @@ type keyInfo struct {
 	tomlType tomlType
 }
 
-func parse(data string, maxNest int) (p *parser, err error) {
+func parse(data string, maxDepth int) (p *parser, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if pErr, ok := r.(ParseError); ok {
@@ -64,7 +65,7 @@ func parse(data string, maxNest int) (p *parser, err error) {
 
 	p = &parser{
 		lx:        lex(data),
-		maxNest:   maxNest,
+		maxDepth:  maxDepth,
 		keyInfo:   make(map[string]keyInfo),
 		mapping:   make(map[string]any),
 		ordered:   make([]Key, 0),
@@ -393,6 +394,12 @@ func missingLeadingZero(d, l string) bool {
 }
 
 func (p *parser) valueArray(it item) (any, tomlType) {
+	if p.maxDepth > 0 && p.arrDepth >= p.maxDepth {
+		p.panicf("exceeds maximum array depth of %d", p.maxDepth)
+	}
+	p.arrDepth++
+	defer func() { p.arrDepth-- }()
+
 	p.setType(p.currentKey, tomlArray, it.pos)
 
 	var (
@@ -539,11 +546,11 @@ func numPeriodsOK(s string) bool {
 // Establishing the context also makes sure that the key isn't a duplicate, and
 // will create implicit hashes automatically.
 func (p *parser) addContext(key Key, array bool) {
-	if p.maxNest > 0 && len(key) >= p.maxNest {
+	if p.maxDepth > 0 && len(key) >= p.maxDepth {
 		// Don't use panicf() helper because we don't want to set LastKey here –
 		// it's going to be a very long string and not very useful.
 		panic(ParseError{
-			Message:  fmt.Sprintf("too many nested tables: can have up to %d nested tables", p.maxNest),
+			Message:  fmt.Sprintf("exceeds maximum table depth of %d", p.maxDepth),
 			Position: p.pos.withCol(p.lx.input),
 			Line:     p.pos.Line,
 		})


### PR DESCRIPTION
It would limit the max depth of tables, but not arrays like:

	a = [[[ 1 ]]] # Well, many more obviously

So also apply it here. And rename to MaxDepth() as it now works for more than just arrays. Also nicer and short.

Fixes #497
Closes #501