### PR TITLE
fix: detect redefinition of an implicit table as a non-table value (#451)

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -249,6 +249,13 @@ func TestDecodeErrors(t *testing.T) {
 			fmt.Sprintf(`value = %d`, math.MaxUint32+int64(1)),
 			map[int]string{32: `toml: line 1 (last key "value"): 4294967296 is out of range for uint`}[strconv.IntSize],
 		},
+		{
+			// Redefining a direct ancestor implicitly created by a dotted key
+			// as a non-table value must be rejected (#451).
+			&map[string]any{},
+			"a.b = \"hello\"\na = 7",
+			`toml: line 2 (last key "a"): Key 'a' has already been defined.`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/parse.go
+++ b/parse.go
@@ -657,6 +657,15 @@ func (p *parser) setValue(key string, value any) {
 			return
 		}
 		if p.isImplicit(keyContext) {
+			// An implicit key (e.g. the "a" created by "a.b = ...") may be
+			// defined concretely later, but only as a table. Redefining it as a
+			// non-table value (e.g. "a = 7") clashes with the implicit table and
+			// is always wrong.
+			if _, oldIsHash := hash[key].(map[string]any); oldIsHash {
+				if _, newIsHash := value.(map[string]any); !newIsHash {
+					p.panicf("Key '%s' has already been defined.", keyContext)
+				}
+			}
 			p.removeImplicit(keyContext)
 			return
 		}

--- a/toml_test.go
+++ b/toml_test.go
@@ -336,7 +336,6 @@ func TestToml(t *testing.T) {
 			"invalid/table/append-with-dotted-keys-01",
 			"invalid/table/append-with-dotted-keys-02",
 			"invalid/table/append-with-dotted-keys-03",
-			"invalid/table/append-with-dotted-keys-05",
 			"invalid/table/append-with-dotted-keys-08",
 			"invalid/table/duplicate-key-04",
 			"invalid/table/duplicate-key-05",


### PR DESCRIPTION
## What

Closes #451.

A dotted key such as `a.b = "x"` implicitly creates table `a`. TOML allows an implicitly-created key to be defined concretely later, but only **as a table** (see `valid/implicit-and-explicit-after`). Redefining it as a non-table value is a spec violation:

```toml
a.b = "hello"
a = 7
```

`a` is a table here, so `a = 7` must be rejected. But it was silently accepted (decoded to `{"a": {"b": "hello"}}`, dropping `a = 7`, with no error).

## Cause

In `setValue`, when a key already exists and is implicit, the code removed the implicit mark and returned unconditionally:

```go
if p.isImplicit(keyContext) {
    p.removeImplicit(keyContext)
    return
}
```

That is correct when the redefinition keeps it a table (`[a.b.c]` then `[a]`), but it also swallowed table→scalar redefinitions.

## Fix

Only silently accept the redefinition when both the existing value and the new value are tables; otherwise report the key as already defined:

```go
if p.isImplicit(keyContext) {
    if _, oldIsHash := hash[key].(map[string]any); oldIsHash {
        if _, newIsHash := value.(map[string]any); !newIsHash {
            p.panicf("Key '%s' has already been defined.", keyContext)
        }
    }
    p.removeImplicit(keyContext)
    return
}
```

Now:

```
$ # a.b = "hello" / a = 7
toml: line 2 (last key "a"): Key 'a' has already been defined.
```

while `[a.b.c]` + `[a]` and `a.b = "x"` + `a.c = "y"` still decode fine.

## Tests

- Added a `TestDecodeErrors` case for the #451 example.
- This fix also makes the previously-skipped `invalid/table/append-with-dotted-keys-05` case from toml-test pass, so it is removed from the skip list in `toml_test.go`.

**Verified RED→GREEN:** without the fix, both the new `TestDecodeErrors` case and `TestToml/invalid/table/append-with-dotted-keys-05` fail; with the fix they pass.

## Validation (real results, Go)

- `go test ./...` — all pass. toml-test conformance: **valid 218/218, invalid 477/477** (invalid count is +1 vs before — one more invalid case now correctly detected), 15 skipped.
- Manually confirmed the two valid redefinition patterns above still decode without error.
- `gofmt -l` and `go vet` clean.
